### PR TITLE
Add LeadingStrings benchmarks for binary and non-ASCII regex patterns

### DIFF
--- a/.azuredevops/dependabot.yml
+++ b/.azuredevops/dependabot.yml
@@ -1,0 +1,5 @@
+version: 2
+
+# Disabling dependabot on Azure DevOps as this is a mirrored repo. Updates should go through github.
+enable-campaigned-updates: false
+enable-security-updates: false

--- a/NuGet.config
+++ b/NuGet.config
@@ -8,8 +8,6 @@
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-android -->
     <add key="darc-pub-dotnet-android-51a08d7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-51a08d74/nuget/v3/index.json" />
-    <add key="darc-pub-dotnet-android-1dcfb6f" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-1dcfb6f8/nuget/v3/index.json" />
-    <add key="darc-pub-dotnet-android-1dcfb6f-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-1dcfb6f8-1/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-android -->
     <!--  Begin: Package sources from dotnet-macios -->
     <add key="darc-pub-dotnet-macios-4177c9d" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-4177c9d9/nuget/v3/index.json" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -31,6 +31,8 @@
     <add key="dotnet-eng" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-eng/nuget/v3/index.json" />
     <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
     <add key="benchmark-dotnet-prerelease" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/benchmark-dotnet-prerelease/nuget/v3/index.json" />
+    <!-- Added manually for .NET 9 MAUI -->
+    <add key="darc-pub-dotnet-maui-7c4f71ad" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-maui-7c4f71ad/nuget/v3/index.json" />
     <!-- Added manually for .NET 8 MAUI -->
     <add key="darc-pub-dotnet-maui-a33a875e" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-maui-a33a875e/nuget/v3/index.json" />
     <!-- Added manually for dotnet/runtime 8.0.18 -->

--- a/NuGet.config
+++ b/NuGet.config
@@ -7,6 +7,7 @@
     <clear />
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->
     <!--  Begin: Package sources from dotnet-android -->
+    <add key="darc-pub-dotnet-android-51a08d7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-51a08d74/nuget/v3/index.json" />
     <add key="darc-pub-dotnet-android-1dcfb6f" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-1dcfb6f8/nuget/v3/index.json" />
     <add key="darc-pub-dotnet-android-1dcfb6f-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-1dcfb6f8-1/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-android -->

--- a/NuGet.config
+++ b/NuGet.config
@@ -12,8 +12,7 @@
     <add key="darc-pub-dotnet-android-1dcfb6f-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-1dcfb6f8-1/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-android -->
     <!--  Begin: Package sources from dotnet-macios -->
-    <add key="darc-pub-dotnet-macios-177f431" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-177f4311/nuget/v3/index.json" />
-    <add key="darc-pub-dotnet-macios-177f431-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-177f4311-1/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-macios-4177c9d" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-4177c9d9/nuget/v3/index.json" />
     <!--  End: Package sources from dotnet-macios -->
     <!--End: Package sources managed by Dependency Flow automation. Do not edit the sources above.-->
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />

--- a/NuGet.config
+++ b/NuGet.config
@@ -44,9 +44,7 @@
     <!-- Added manually for .NET 8 Android -->
     <add key="darc-pub-dotnet-android-cdb777a" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-android-cdb777a0/nuget/v3/index.json" />
     <!-- Added manually for .NET 9 macios -->
-    <add key="darc-pub-dotnet-macios-0e1a194" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-0e1a194f/nuget/v3/index.json" />
-    <add key="darc-pub-dotnet-macios-0e1a194-1" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-0e1a194f-1/nuget/v3/index.json" />
-    <add key="darc-pub-dotnet-macios-af20d0b" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-af20d0b6/nuget/v3/index.json" />
+    <add key="darc-pub-dotnet-macios-8d30875" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-macios-8d308759/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <!--Begin: Package sources managed by Dependency Flow automation. Do not edit the sources below.-->

--- a/docs/README.md
+++ b/docs/README.md
@@ -30,8 +30,7 @@ The documentation in this repo is organized into the following sections:
 - [Testing GC.Infrastructure](../src/benchmarks/gc/GC.Infrastructure/README.md) - Information on testing GC.Infrastructure.
 - [GC.Analysis.API](../src/benchmarks/gc/GC.Infrastructure/GC.Analysis.API/README.md) - Information on conducting GC, CPU and Threading analysis using .NET Interactive notebooks.
 - [GC.Infrastructure Notebooks](../src/benchmarks/gc/GC.Infrastructure/Notebooks/README.md) - Information on notebooks that either provide examples or functionality for specialized analysis
-- [Benchmark Analysis](../src/benchmarks/gc/GC.Infrastructure/Notebooks/BenchmarkAnalysis.md) - Information on a notebook which contains code for producing charts (and soon, tables) for GC benchmarks. It can currently process data
-from the ASP.NET benchmarks obtained using crank as well as ETL data.
+- [Benchmark Analysis](../src/benchmarks/gc/GC.Infrastructure/Notebooks/BenchmarkAnalysis.md) - Information on a notebook which contains code for producing charts (and soon, tables) for GC benchmarks. It can currently process data from the ASP.NET benchmarks obtained using crank as well as ETL data.
 
 ## Running Scenarios
 

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -94,21 +94,21 @@
     </Dependency>
     <!-- Previous .NET iOS version(s) -->
     <!-- This is a subscription of the .NET 9 latest stable versions of our packages -->
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net9.0_26.0" Version="26.0.9752">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net9.0_26.0" Version="26.0.9754">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>177f4311930b32eecc1e462a71ebbe34b7e01a0b</Sha>
+      <Sha>4177c9d9590857cfb2617fd7a7ef3d5e1de48ed3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net9.0_26.0" Version="26.0.9752">
+    <Dependency Name="Microsoft.macOS.Sdk.net9.0_26.0" Version="26.0.9754">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>177f4311930b32eecc1e462a71ebbe34b7e01a0b</Sha>
+      <Sha>4177c9d9590857cfb2617fd7a7ef3d5e1de48ed3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net9.0_26.0" Version="26.0.9752">
+    <Dependency Name="Microsoft.iOS.Sdk.net9.0_26.0" Version="26.0.9754">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>177f4311930b32eecc1e462a71ebbe34b7e01a0b</Sha>
+      <Sha>4177c9d9590857cfb2617fd7a7ef3d5e1de48ed3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net9.0_26.0" Version="26.0.9752">
+    <Dependency Name="Microsoft.tvOS.Sdk.net9.0_26.0" Version="26.0.9754">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>177f4311930b32eecc1e462a71ebbe34b7e01a0b</Sha>
+      <Sha>4177c9d9590857cfb2617fd7a7ef3d5e1de48ed3</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -35,9 +35,9 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>994d9ebe9f3f4216d7b125738cf5c19adaf674d3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="10.0.0-prerelease.25475.1">
+    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="11.0.0-prerelease.25603.1">
       <Uri>https://github.com/dotnet/xharness</Uri>
-      <Sha>d9aba438cae0eb814085c71dd6caa19e99c8e052</Sha>
+      <Sha>3df2923500447ee925d59f026c81720c7a9b4e4b</Sha>
     </Dependency>
     <!--
       Maui Rollback Version mappings, default means generated from sdk version. Allows for manual override of version similar to https://github.com/dotnet/maui/blob/df8cfcf635a590955a8cc3d6cf7ae6280449dd3f/eng/Versions.props#L138-L146, where the logic comes from:

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -76,37 +76,55 @@
       <Uri>https://github.com/dotnet/android</Uri>
       <Sha>1dcfb6f8779c33b6f768c996495cb90ecd729329</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_18.5" Version="18.5.10824-net10-rc.2">
+    <!-- .NET 11 iOS version(s) -->
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_26.1" Version="26.1.10555-ci.net11-0">
+      <Uri>https://github.com/dotnet/macios</Uri>
+      <Sha>1ebe913b290f8d1bc0f770eb07fa98b199b61e8f</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.macOS.Sdk.net10.0_26.1" Version="26.1.10555-ci.net11-0">
+      <Uri>https://github.com/dotnet/macios</Uri>
+      <Sha>1ebe913b290f8d1bc0f770eb07fa98b199b61e8f</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.iOS.Sdk.net10.0_26.1" Version="26.1.10555-ci.net11-0">
+      <Uri>https://github.com/dotnet/macios</Uri>
+      <Sha>1ebe913b290f8d1bc0f770eb07fa98b199b61e8f</Sha>
+    </Dependency>
+    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_26.1" Version="26.1.10555-ci.net11-0">
+      <Uri>https://github.com/dotnet/macios</Uri>
+      <Sha>1ebe913b290f8d1bc0f770eb07fa98b199b61e8f</Sha>
+    </Dependency>
+    <!-- .NET 10 iOS version(s) -->
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_18.5" Version="18.5.10824-net10-rc.2" CoherentParentDependency="Microsoft.MacCatalyst.Sdk.net10.0_26.1">
       <Uri>https://github.com/dotnet/macios</Uri>
       <Sha>890175615f7762dfbc4f8555007aaf5bb4d75c8f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net10.0_15.5" Version="15.5.10824-net10-rc.2">
+    <Dependency Name="Microsoft.macOS.Sdk.net10.0_15.5" Version="15.5.10824-net10-rc.2" CoherentParentDependency="Microsoft.macOS.Sdk.net10.0_26.1">
       <Uri>https://github.com/dotnet/macios</Uri>
       <Sha>890175615f7762dfbc4f8555007aaf5bb4d75c8f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net10.0_18.5" Version="18.5.10824-net10-rc.2">
+    <Dependency Name="Microsoft.iOS.Sdk.net10.0_18.5" Version="18.5.10824-net10-rc.2" CoherentParentDependency="Microsoft.iOS.Sdk.net10.0_26.1">
       <Uri>https://github.com/dotnet/macios</Uri>
       <Sha>890175615f7762dfbc4f8555007aaf5bb4d75c8f</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_18.5" Version="18.5.10824-net10-rc.2">
+    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_18.5" Version="18.5.10824-net10-rc.2" CoherentParentDependency="Microsoft.tvOS.Sdk.net10.0_26.1">
       <Uri>https://github.com/dotnet/macios</Uri>
       <Sha>890175615f7762dfbc4f8555007aaf5bb4d75c8f</Sha>
     </Dependency>
-    <!-- Previous .NET iOS version(s) -->
+    <!-- .NET 9 iOS version(s) -->
     <!-- This is a subscription of the .NET 9 latest stable versions of our packages -->
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net9.0_26.0" Version="26.0.9754">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net9.0_26.0" Version="26.0.9754" CoherentParentDependency="Microsoft.MacCatalyst.Sdk.net10.0_26.1">
       <Uri>https://github.com/dotnet/macios</Uri>
       <Sha>4177c9d9590857cfb2617fd7a7ef3d5e1de48ed3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net9.0_26.0" Version="26.0.9754">
+    <Dependency Name="Microsoft.macOS.Sdk.net9.0_26.0" Version="26.0.9754" CoherentParentDependency="Microsoft.macOS.Sdk.net10.0_26.1">
       <Uri>https://github.com/dotnet/macios</Uri>
       <Sha>4177c9d9590857cfb2617fd7a7ef3d5e1de48ed3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net9.0_26.0" Version="26.0.9754">
+    <Dependency Name="Microsoft.iOS.Sdk.net9.0_26.0" Version="26.0.9754" CoherentParentDependency="Microsoft.iOS.Sdk.net10.0_26.1">
       <Uri>https://github.com/dotnet/macios</Uri>
       <Sha>4177c9d9590857cfb2617fd7a7ef3d5e1de48ed3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net9.0_26.0" Version="26.0.9754">
+    <Dependency Name="Microsoft.tvOS.Sdk.net9.0_26.0" Version="26.0.9754" CoherentParentDependency="Microsoft.tvOS.Sdk.net10.0_26.1">
       <Uri>https://github.com/dotnet/macios</Uri>
       <Sha>4177c9d9590857cfb2617fd7a7ef3d5e1de48ed3</Sha>
     </Dependency>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -77,56 +77,38 @@
       <Sha>1dcfb6f8779c33b6f768c996495cb90ecd729329</Sha>
     </Dependency>
     <!-- .NET 11 iOS version(s) -->
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_26.1" Version="26.1.10555-ci.net11-0">
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net11.0_26.2" Version="26.2.11244-ci.net11-0">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>1ebe913b290f8d1bc0f770eb07fa98b199b61e8f</Sha>
+      <Sha>72f6ce856be41316c4d54d8d0cb3e90cd8b1a2ae</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net10.0_26.1" Version="26.1.10555-ci.net11-0">
+    <Dependency Name="Microsoft.macOS.Sdk.net11.0_26.2" Version="26.2.11244-ci.net11-0">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>1ebe913b290f8d1bc0f770eb07fa98b199b61e8f</Sha>
+      <Sha>72f6ce856be41316c4d54d8d0cb3e90cd8b1a2ae</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net10.0_26.1" Version="26.1.10555-ci.net11-0">
+    <Dependency Name="Microsoft.iOS.Sdk.net11.0_26.2" Version="26.2.11244-ci.net11-0">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>1ebe913b290f8d1bc0f770eb07fa98b199b61e8f</Sha>
+      <Sha>72f6ce856be41316c4d54d8d0cb3e90cd8b1a2ae</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_26.1" Version="26.1.10555-ci.net11-0">
+    <Dependency Name="Microsoft.tvOS.Sdk.net11.0_26.2" Version="26.2.11244-ci.net11-0">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>1ebe913b290f8d1bc0f770eb07fa98b199b61e8f</Sha>
+      <Sha>72f6ce856be41316c4d54d8d0cb3e90cd8b1a2ae</Sha>
     </Dependency>
-    <!-- .NET 10 iOS version(s) -->
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_18.5" Version="18.5.10824-net10-rc.2" CoherentParentDependency="Microsoft.MacCatalyst.Sdk.net10.0_26.1">
+    <!-- Previous .NET iOS version(s) -->
+    <Dependency Name="Microsoft.MacCatalyst.Sdk.net10.0_26.2" Version="26.2.10192" CoherentParentDependency="Microsoft.MacCatalyst.Sdk.net11.0_26.2">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>890175615f7762dfbc4f8555007aaf5bb4d75c8f</Sha>
+      <Sha>8d3087594c224f1a5a2d6f9fdd2ca01d02e370ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net10.0_15.5" Version="15.5.10824-net10-rc.2" CoherentParentDependency="Microsoft.macOS.Sdk.net10.0_26.1">
+    <Dependency Name="Microsoft.macOS.Sdk.net10.0_26.2" Version="26.2.10192" CoherentParentDependency="Microsoft.macOS.Sdk.net11.0_26.2">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>890175615f7762dfbc4f8555007aaf5bb4d75c8f</Sha>
+      <Sha>8d3087594c224f1a5a2d6f9fdd2ca01d02e370ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net10.0_18.5" Version="18.5.10824-net10-rc.2" CoherentParentDependency="Microsoft.iOS.Sdk.net10.0_26.1">
+    <Dependency Name="Microsoft.iOS.Sdk.net10.0_26.2" Version="26.2.10192" CoherentParentDependency="Microsoft.iOS.Sdk.net11.0_26.2">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>890175615f7762dfbc4f8555007aaf5bb4d75c8f</Sha>
+      <Sha>8d3087594c224f1a5a2d6f9fdd2ca01d02e370ca</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_18.5" Version="18.5.10824-net10-rc.2" CoherentParentDependency="Microsoft.tvOS.Sdk.net10.0_26.1">
+    <Dependency Name="Microsoft.tvOS.Sdk.net10.0_26.2" Version="26.2.10192" CoherentParentDependency="Microsoft.tvOS.Sdk.net11.0_26.2">
       <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>890175615f7762dfbc4f8555007aaf5bb4d75c8f</Sha>
-    </Dependency>
-    <!-- .NET 9 iOS version(s) -->
-    <!-- This is a subscription of the .NET 9 latest stable versions of our packages -->
-    <Dependency Name="Microsoft.MacCatalyst.Sdk.net9.0_26.0" Version="26.0.9754" CoherentParentDependency="Microsoft.MacCatalyst.Sdk.net10.0_26.1">
-      <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>4177c9d9590857cfb2617fd7a7ef3d5e1de48ed3</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.macOS.Sdk.net9.0_26.0" Version="26.0.9754" CoherentParentDependency="Microsoft.macOS.Sdk.net10.0_26.1">
-      <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>4177c9d9590857cfb2617fd7a7ef3d5e1de48ed3</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.iOS.Sdk.net9.0_26.0" Version="26.0.9754" CoherentParentDependency="Microsoft.iOS.Sdk.net10.0_26.1">
-      <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>4177c9d9590857cfb2617fd7a7ef3d5e1de48ed3</Sha>
-    </Dependency>
-    <Dependency Name="Microsoft.tvOS.Sdk.net9.0_26.0" Version="26.0.9754" CoherentParentDependency="Microsoft.tvOS.Sdk.net10.0_26.1">
-      <Uri>https://github.com/dotnet/macios</Uri>
-      <Sha>4177c9d9590857cfb2617fd7a7ef3d5e1de48ed3</Sha>
+      <Sha>8d3087594c224f1a5a2d6f9fdd2ca01d02e370ca</Sha>
     </Dependency>
   </ToolsetDependencies>
 </Dependencies>

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,39 +1,39 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="10.0.0-rc.1.25479.101">
+    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="10.0.0-rc.1.25508.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3d931f25d78159d75a7209e0f10adf49e2eea3c9</Sha>
+      <Sha>64d877a07af8c020fe9da6e721bc2258894f31ee</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink" Version="10.0.0-rc.1.25479.101">
+    <Dependency Name="Microsoft.NET.ILLink" Version="10.0.0-rc.1.25508.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3d931f25d78159d75a7209e0f10adf49e2eea3c9</Sha>
+      <Sha>64d877a07af8c020fe9da6e721bc2258894f31ee</Sha>
     </Dependency>
-    <Dependency Name="System.Threading.Channels" Version="10.0.0-rc.1.25479.101">
+    <Dependency Name="System.Threading.Channels" Version="10.0.0-rc.1.25508.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3d931f25d78159d75a7209e0f10adf49e2eea3c9</Sha>
+      <Sha>64d877a07af8c020fe9da6e721bc2258894f31ee</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="10.0.0-rc.1.25479.101">
+    <Dependency Name="Microsoft.Extensions.Logging" Version="10.0.0-rc.1.25508.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3d931f25d78159d75a7209e0f10adf49e2eea3c9</Sha>
+      <Sha>64d877a07af8c020fe9da6e721bc2258894f31ee</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.WindowsDesktop.App.Ref" Version="10.0.0-rc.1.25479.101">
+    <Dependency Name="Microsoft.WindowsDesktop.App.Ref" Version="10.0.0-rc.1.25508.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3d931f25d78159d75a7209e0f10adf49e2eea3c9</Sha>
+      <Sha>64d877a07af8c020fe9da6e721bc2258894f31ee</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Runtime.Emscripten.3.1.56.Node.win-x64" Version="10.0.0-rc.1.25479.101">
+    <Dependency Name="Microsoft.NET.Runtime.Emscripten.3.1.56.Node.win-x64" Version="10.0.0-rc.1.25508.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3d931f25d78159d75a7209e0f10adf49e2eea3c9</Sha>
+      <Sha>64d877a07af8c020fe9da6e721bc2258894f31ee</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.25479.101">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.25508.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3d931f25d78159d75a7209e0f10adf49e2eea3c9</Sha>
+      <Sha>64d877a07af8c020fe9da6e721bc2258894f31ee</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.25479.101">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.25508.109">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>3d931f25d78159d75a7209e0f10adf49e2eea3c9</Sha>
+      <Sha>64d877a07af8c020fe9da6e721bc2258894f31ee</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="10.0.0-prerelease.25475.1">
       <Uri>https://github.com/dotnet/xharness</Uri>
@@ -55,12 +55,12 @@
       <Sha>88c2c7ae772437921d85186318dd4320c4848618</Sha>
       <Uri>https://github.com/dotnet/maui</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="10.0.100-rc.2.25479.101">
-      <Sha>3d931f25d78159d75a7209e0f10adf49e2eea3c9</Sha>
+    <Dependency Name="Microsoft.NET.Sdk" Version="10.0.100-rc.2.25508.109">
+      <Sha>64d877a07af8c020fe9da6e721bc2258894f31ee</Sha>
       <Uri>https://github.com/dotnet/dotnet</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="10.0.0-rc.1.25479.101">
-      <Sha>3d931f25d78159d75a7209e0f10adf49e2eea3c9</Sha>
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="10.0.0-rc.1.25508.109">
+      <Sha>64d877a07af8c020fe9da6e721bc2258894f31ee</Sha>
       <Uri>https://github.com/dotnet/dotnet</Uri>
     </Dependency>
     <Dependency Name="Microsoft.Android.Sdk.Windows" Version="36.0.9">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,39 +1,39 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="10.0.0-rc.1.25514.106">
+    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="10.0.0-rc.1.25555.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2d4079aa0b0ae84217540e6df5dcc15e8a64c07d</Sha>
+      <Sha>994d9ebe9f3f4216d7b125738cf5c19adaf674d3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink" Version="10.0.0-rc.1.25514.106">
+    <Dependency Name="Microsoft.NET.ILLink" Version="10.0.0-rc.1.25555.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2d4079aa0b0ae84217540e6df5dcc15e8a64c07d</Sha>
+      <Sha>994d9ebe9f3f4216d7b125738cf5c19adaf674d3</Sha>
     </Dependency>
-    <Dependency Name="System.Threading.Channels" Version="10.0.0-rc.1.25514.106">
+    <Dependency Name="System.Threading.Channels" Version="10.0.0-rc.1.25555.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2d4079aa0b0ae84217540e6df5dcc15e8a64c07d</Sha>
+      <Sha>994d9ebe9f3f4216d7b125738cf5c19adaf674d3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="10.0.0-rc.1.25514.106">
+    <Dependency Name="Microsoft.Extensions.Logging" Version="10.0.0-rc.1.25555.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2d4079aa0b0ae84217540e6df5dcc15e8a64c07d</Sha>
+      <Sha>994d9ebe9f3f4216d7b125738cf5c19adaf674d3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.WindowsDesktop.App.Ref" Version="10.0.0-rc.1.25514.106">
+    <Dependency Name="Microsoft.WindowsDesktop.App.Ref" Version="10.0.0-rc.1.25555.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2d4079aa0b0ae84217540e6df5dcc15e8a64c07d</Sha>
+      <Sha>994d9ebe9f3f4216d7b125738cf5c19adaf674d3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Runtime.Emscripten.3.1.56.Node.win-x64" Version="10.0.0-rc.1.25514.106">
+    <Dependency Name="Microsoft.NET.Runtime.Emscripten.3.1.56.Node.win-x64" Version="10.0.0-rc.1.25555.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2d4079aa0b0ae84217540e6df5dcc15e8a64c07d</Sha>
+      <Sha>994d9ebe9f3f4216d7b125738cf5c19adaf674d3</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.25514.106">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.25555.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2d4079aa0b0ae84217540e6df5dcc15e8a64c07d</Sha>
+      <Sha>994d9ebe9f3f4216d7b125738cf5c19adaf674d3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.25514.106">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.25555.107">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>2d4079aa0b0ae84217540e6df5dcc15e8a64c07d</Sha>
+      <Sha>994d9ebe9f3f4216d7b125738cf5c19adaf674d3</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="10.0.0-prerelease.25475.1">
       <Uri>https://github.com/dotnet/xharness</Uri>
@@ -55,12 +55,12 @@
       <Sha>88c2c7ae772437921d85186318dd4320c4848618</Sha>
       <Uri>https://github.com/dotnet/maui</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="10.0.100-rc.2.25514.106">
-      <Sha>2d4079aa0b0ae84217540e6df5dcc15e8a64c07d</Sha>
+    <Dependency Name="Microsoft.NET.Sdk" Version="10.0.100-rc.2.25555.107">
+      <Sha>994d9ebe9f3f4216d7b125738cf5c19adaf674d3</Sha>
       <Uri>https://github.com/dotnet/dotnet</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="10.0.0-rc.1.25514.106">
-      <Sha>2d4079aa0b0ae84217540e6df5dcc15e8a64c07d</Sha>
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="10.0.0-rc.1.25555.107">
+      <Sha>994d9ebe9f3f4216d7b125738cf5c19adaf674d3</Sha>
       <Uri>https://github.com/dotnet/dotnet</Uri>
     </Dependency>
     <Dependency Name="Microsoft.Android.Sdk.Windows" Version="36.0.9">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -1,39 +1,39 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Dependencies>
   <ProductDependencies>
-    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="10.0.0-rc.1.25508.109">
+    <Dependency Name="Microsoft.NET.ILLink.Tasks" Version="10.0.0-rc.1.25514.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>64d877a07af8c020fe9da6e721bc2258894f31ee</Sha>
+      <Sha>2d4079aa0b0ae84217540e6df5dcc15e8a64c07d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.ILLink" Version="10.0.0-rc.1.25508.109">
+    <Dependency Name="Microsoft.NET.ILLink" Version="10.0.0-rc.1.25514.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>64d877a07af8c020fe9da6e721bc2258894f31ee</Sha>
+      <Sha>2d4079aa0b0ae84217540e6df5dcc15e8a64c07d</Sha>
     </Dependency>
-    <Dependency Name="System.Threading.Channels" Version="10.0.0-rc.1.25508.109">
+    <Dependency Name="System.Threading.Channels" Version="10.0.0-rc.1.25514.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>64d877a07af8c020fe9da6e721bc2258894f31ee</Sha>
+      <Sha>2d4079aa0b0ae84217540e6df5dcc15e8a64c07d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.Extensions.Logging" Version="10.0.0-rc.1.25508.109">
+    <Dependency Name="Microsoft.Extensions.Logging" Version="10.0.0-rc.1.25514.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>64d877a07af8c020fe9da6e721bc2258894f31ee</Sha>
+      <Sha>2d4079aa0b0ae84217540e6df5dcc15e8a64c07d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.WindowsDesktop.App.Ref" Version="10.0.0-rc.1.25508.109">
+    <Dependency Name="Microsoft.WindowsDesktop.App.Ref" Version="10.0.0-rc.1.25514.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>64d877a07af8c020fe9da6e721bc2258894f31ee</Sha>
+      <Sha>2d4079aa0b0ae84217540e6df5dcc15e8a64c07d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Runtime.Emscripten.3.1.56.Node.win-x64" Version="10.0.0-rc.1.25508.109">
+    <Dependency Name="Microsoft.NET.Runtime.Emscripten.3.1.56.Node.win-x64" Version="10.0.0-rc.1.25514.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>64d877a07af8c020fe9da6e721bc2258894f31ee</Sha>
+      <Sha>2d4079aa0b0ae84217540e6df5dcc15e8a64c07d</Sha>
     </Dependency>
   </ProductDependencies>
   <ToolsetDependencies>
-    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.25508.109">
+    <Dependency Name="Microsoft.DotNet.Arcade.Sdk" Version="11.0.0-beta.25514.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>64d877a07af8c020fe9da6e721bc2258894f31ee</Sha>
+      <Sha>2d4079aa0b0ae84217540e6df5dcc15e8a64c07d</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.25508.109">
+    <Dependency Name="Microsoft.DotNet.Helix.Sdk" Version="11.0.0-beta.25514.106">
       <Uri>https://github.com/dotnet/dotnet</Uri>
-      <Sha>64d877a07af8c020fe9da6e721bc2258894f31ee</Sha>
+      <Sha>2d4079aa0b0ae84217540e6df5dcc15e8a64c07d</Sha>
     </Dependency>
     <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="10.0.0-prerelease.25475.1">
       <Uri>https://github.com/dotnet/xharness</Uri>
@@ -55,12 +55,12 @@
       <Sha>88c2c7ae772437921d85186318dd4320c4848618</Sha>
       <Uri>https://github.com/dotnet/maui</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.NET.Sdk" Version="10.0.100-rc.2.25508.109">
-      <Sha>64d877a07af8c020fe9da6e721bc2258894f31ee</Sha>
+    <Dependency Name="Microsoft.NET.Sdk" Version="10.0.100-rc.2.25514.106">
+      <Sha>2d4079aa0b0ae84217540e6df5dcc15e8a64c07d</Sha>
       <Uri>https://github.com/dotnet/dotnet</Uri>
     </Dependency>
-    <Dependency Name="Microsoft.NETCore.App.Ref" Version="10.0.0-rc.1.25508.109">
-      <Sha>64d877a07af8c020fe9da6e721bc2258894f31ee</Sha>
+    <Dependency Name="Microsoft.NETCore.App.Ref" Version="10.0.0-rc.1.25514.106">
+      <Sha>2d4079aa0b0ae84217540e6df5dcc15e8a64c07d</Sha>
       <Uri>https://github.com/dotnet/dotnet</Uri>
     </Dependency>
     <Dependency Name="Microsoft.Android.Sdk.Windows" Version="36.0.9">

--- a/eng/Version.Details.xml
+++ b/eng/Version.Details.xml
@@ -35,9 +35,9 @@
       <Uri>https://github.com/dotnet/dotnet</Uri>
       <Sha>994d9ebe9f3f4216d7b125738cf5c19adaf674d3</Sha>
     </Dependency>
-    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="11.0.0-prerelease.25603.1">
+    <Dependency Name="Microsoft.DotNet.XHarness.CLI" Version="11.0.0-prerelease.26064.3">
       <Uri>https://github.com/dotnet/xharness</Uri>
-      <Sha>3df2923500447ee925d59f026c81720c7a9b4e4b</Sha>
+      <Sha>31e0b8e08f57890f7b7004b93361d69cd4b21079</Sha>
     </Dependency>
     <!--
       Maui Rollback Version mappings, default means generated from sdk version. Allows for manual override of version similar to https://github.com/dotnet/maui/blob/df8cfcf635a590955a8cc3d6cf7ae6280449dd3f/eng/Versions.props#L138-L146, where the logic comes from:

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,7 +11,7 @@
     <MicrosoftNETILLinkPackageVersion>10.0.0-rc.1.25555.107</MicrosoftNETILLinkPackageVersion>
     <SystemThreadingChannelsPackageVersion>10.0.0-rc.1.25555.107</SystemThreadingChannelsPackageVersion>
     <MicrosoftExtensionsLoggingPackageVersion>10.0.0-rc.1.25555.107</MicrosoftExtensionsLoggingPackageVersion>
-    <BenchmarkDotNetVersion>0.16.0-custom.20260120.101</BenchmarkDotNetVersion>
+    <BenchmarkDotNetVersion>0.16.0-custom.20260127.101</BenchmarkDotNetVersion>
     <MicrosoftNETRuntimeEmscripten3156Nodewinx64Version>10.0.0-rc.1.25555.107</MicrosoftNETRuntimeEmscripten3156Nodewinx64Version>
     <MicrosoftDotNetXHarnessCLIVersion>11.0.0-prerelease.26064.3</MicrosoftDotNetXHarnessCLIVersion>
   </PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,12 +7,12 @@
   </PropertyGroup>
   <!--Package versions-->
   <PropertyGroup>
-    <MicrosoftNETILLinkTasksVersion>10.0.0-rc.1.25479.101</MicrosoftNETILLinkTasksVersion>
-    <MicrosoftNETILLinkPackageVersion>10.0.0-rc.1.25479.101</MicrosoftNETILLinkPackageVersion>
-    <SystemThreadingChannelsPackageVersion>10.0.0-rc.1.25479.101</SystemThreadingChannelsPackageVersion>
-    <MicrosoftExtensionsLoggingPackageVersion>10.0.0-rc.1.25479.101</MicrosoftExtensionsLoggingPackageVersion>
+    <MicrosoftNETILLinkTasksVersion>10.0.0-rc.1.25508.109</MicrosoftNETILLinkTasksVersion>
+    <MicrosoftNETILLinkPackageVersion>10.0.0-rc.1.25508.109</MicrosoftNETILLinkPackageVersion>
+    <SystemThreadingChannelsPackageVersion>10.0.0-rc.1.25508.109</SystemThreadingChannelsPackageVersion>
+    <MicrosoftExtensionsLoggingPackageVersion>10.0.0-rc.1.25508.109</MicrosoftExtensionsLoggingPackageVersion>
     <BenchmarkDotNetVersion>0.14.1-nightly.20250107.205</BenchmarkDotNetVersion>
-    <MicrosoftNETRuntimeEmscripten3156Nodewinx64Version>10.0.0-rc.1.25479.101</MicrosoftNETRuntimeEmscripten3156Nodewinx64Version>
+    <MicrosoftNETRuntimeEmscripten3156Nodewinx64Version>10.0.0-rc.1.25508.109</MicrosoftNETRuntimeEmscripten3156Nodewinx64Version>
     <MicrosoftDotNetXHarnessCLIVersion>10.0.0-prerelease.25475.1</MicrosoftDotNetXHarnessCLIVersion>
   </PropertyGroup>
   <!--Package names-->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,12 +7,12 @@
   </PropertyGroup>
   <!--Package versions-->
   <PropertyGroup>
-    <MicrosoftNETILLinkTasksVersion>10.0.0-rc.1.25508.109</MicrosoftNETILLinkTasksVersion>
-    <MicrosoftNETILLinkPackageVersion>10.0.0-rc.1.25508.109</MicrosoftNETILLinkPackageVersion>
-    <SystemThreadingChannelsPackageVersion>10.0.0-rc.1.25508.109</SystemThreadingChannelsPackageVersion>
-    <MicrosoftExtensionsLoggingPackageVersion>10.0.0-rc.1.25508.109</MicrosoftExtensionsLoggingPackageVersion>
+    <MicrosoftNETILLinkTasksVersion>10.0.0-rc.1.25514.106</MicrosoftNETILLinkTasksVersion>
+    <MicrosoftNETILLinkPackageVersion>10.0.0-rc.1.25514.106</MicrosoftNETILLinkPackageVersion>
+    <SystemThreadingChannelsPackageVersion>10.0.0-rc.1.25514.106</SystemThreadingChannelsPackageVersion>
+    <MicrosoftExtensionsLoggingPackageVersion>10.0.0-rc.1.25514.106</MicrosoftExtensionsLoggingPackageVersion>
     <BenchmarkDotNetVersion>0.14.1-nightly.20250107.205</BenchmarkDotNetVersion>
-    <MicrosoftNETRuntimeEmscripten3156Nodewinx64Version>10.0.0-rc.1.25508.109</MicrosoftNETRuntimeEmscripten3156Nodewinx64Version>
+    <MicrosoftNETRuntimeEmscripten3156Nodewinx64Version>10.0.0-rc.1.25514.106</MicrosoftNETRuntimeEmscripten3156Nodewinx64Version>
     <MicrosoftDotNetXHarnessCLIVersion>10.0.0-prerelease.25475.1</MicrosoftDotNetXHarnessCLIVersion>
   </PropertyGroup>
   <!--Package names-->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,7 +13,7 @@
     <MicrosoftExtensionsLoggingPackageVersion>10.0.0-rc.1.25555.107</MicrosoftExtensionsLoggingPackageVersion>
     <BenchmarkDotNetVersion>0.16.0-custom.20260120.101</BenchmarkDotNetVersion>
     <MicrosoftNETRuntimeEmscripten3156Nodewinx64Version>10.0.0-rc.1.25555.107</MicrosoftNETRuntimeEmscripten3156Nodewinx64Version>
-    <MicrosoftDotNetXHarnessCLIVersion>11.0.0-prerelease.25603.1</MicrosoftDotNetXHarnessCLIVersion>
+    <MicrosoftDotNetXHarnessCLIVersion>11.0.0-prerelease.26064.3</MicrosoftDotNetXHarnessCLIVersion>
   </PropertyGroup>
   <!--Package names-->
   <PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -7,12 +7,12 @@
   </PropertyGroup>
   <!--Package versions-->
   <PropertyGroup>
-    <MicrosoftNETILLinkTasksVersion>10.0.0-rc.1.25514.106</MicrosoftNETILLinkTasksVersion>
-    <MicrosoftNETILLinkPackageVersion>10.0.0-rc.1.25514.106</MicrosoftNETILLinkPackageVersion>
-    <SystemThreadingChannelsPackageVersion>10.0.0-rc.1.25514.106</SystemThreadingChannelsPackageVersion>
-    <MicrosoftExtensionsLoggingPackageVersion>10.0.0-rc.1.25514.106</MicrosoftExtensionsLoggingPackageVersion>
+    <MicrosoftNETILLinkTasksVersion>10.0.0-rc.1.25555.107</MicrosoftNETILLinkTasksVersion>
+    <MicrosoftNETILLinkPackageVersion>10.0.0-rc.1.25555.107</MicrosoftNETILLinkPackageVersion>
+    <SystemThreadingChannelsPackageVersion>10.0.0-rc.1.25555.107</SystemThreadingChannelsPackageVersion>
+    <MicrosoftExtensionsLoggingPackageVersion>10.0.0-rc.1.25555.107</MicrosoftExtensionsLoggingPackageVersion>
     <BenchmarkDotNetVersion>0.14.1-nightly.20250107.205</BenchmarkDotNetVersion>
-    <MicrosoftNETRuntimeEmscripten3156Nodewinx64Version>10.0.0-rc.1.25514.106</MicrosoftNETRuntimeEmscripten3156Nodewinx64Version>
+    <MicrosoftNETRuntimeEmscripten3156Nodewinx64Version>10.0.0-rc.1.25555.107</MicrosoftNETRuntimeEmscripten3156Nodewinx64Version>
     <MicrosoftDotNetXHarnessCLIVersion>10.0.0-prerelease.25475.1</MicrosoftDotNetXHarnessCLIVersion>
   </PropertyGroup>
   <!--Package names-->

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,7 +11,7 @@
     <MicrosoftNETILLinkPackageVersion>10.0.0-rc.1.25555.107</MicrosoftNETILLinkPackageVersion>
     <SystemThreadingChannelsPackageVersion>10.0.0-rc.1.25555.107</SystemThreadingChannelsPackageVersion>
     <MicrosoftExtensionsLoggingPackageVersion>10.0.0-rc.1.25555.107</MicrosoftExtensionsLoggingPackageVersion>
-    <BenchmarkDotNetVersion>0.14.1-nightly.20250107.205</BenchmarkDotNetVersion>
+    <BenchmarkDotNetVersion>0.16.0-custom.20260120.101</BenchmarkDotNetVersion>
     <MicrosoftNETRuntimeEmscripten3156Nodewinx64Version>10.0.0-rc.1.25555.107</MicrosoftNETRuntimeEmscripten3156Nodewinx64Version>
     <MicrosoftDotNetXHarnessCLIVersion>11.0.0-prerelease.25603.1</MicrosoftDotNetXHarnessCLIVersion>
   </PropertyGroup>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -13,7 +13,7 @@
     <MicrosoftExtensionsLoggingPackageVersion>10.0.0-rc.1.25555.107</MicrosoftExtensionsLoggingPackageVersion>
     <BenchmarkDotNetVersion>0.14.1-nightly.20250107.205</BenchmarkDotNetVersion>
     <MicrosoftNETRuntimeEmscripten3156Nodewinx64Version>10.0.0-rc.1.25555.107</MicrosoftNETRuntimeEmscripten3156Nodewinx64Version>
-    <MicrosoftDotNetXHarnessCLIVersion>10.0.0-prerelease.25475.1</MicrosoftDotNetXHarnessCLIVersion>
+    <MicrosoftDotNetXHarnessCLIVersion>11.0.0-prerelease.25603.1</MicrosoftDotNetXHarnessCLIVersion>
   </PropertyGroup>
   <!--Package names-->
   <PropertyGroup>

--- a/eng/common/SetupNugetSources.ps1
+++ b/eng/common/SetupNugetSources.ps1
@@ -7,7 +7,7 @@
 # See example call for this script below.
 #
 #  - task: PowerShell@2
-#    displayName: Setup Private Feeds Credentials
+#    displayName: Setup internal Feeds Credentials
 #    condition: eq(variables['Agent.OS'], 'Windows_NT')
 #    inputs:
 #      filePath: $(System.DefaultWorkingDirectory)/eng/common/SetupNugetSources.ps1
@@ -34,19 +34,28 @@ Set-StrictMode -Version 2.0
 
 . $PSScriptRoot\tools.ps1
 
+# Adds or enables the package source with the given name
+function AddOrEnablePackageSource($sources, $disabledPackageSources, $SourceName, $SourceEndPoint, $creds, $Username, $pwd) {
+    if ($disabledPackageSources -eq $null -or -not (EnableInternalPackageSource -DisabledPackageSources $disabledPackageSources -Creds $creds -PackageSourceName $SourceName)) {
+        AddPackageSource -Sources $sources -SourceName $SourceName -SourceEndPoint $SourceEndPoint -Creds $creds -Username $userName -pwd $Password
+    }
+}
+
 # Add source entry to PackageSources
 function AddPackageSource($sources, $SourceName, $SourceEndPoint, $creds, $Username, $pwd) {
     $packageSource = $sources.SelectSingleNode("add[@key='$SourceName']")
     
     if ($packageSource -eq $null)
     {
+        Write-Host "Adding package source $SourceName"
+
         $packageSource = $doc.CreateElement("add")
         $packageSource.SetAttribute("key", $SourceName)
         $packageSource.SetAttribute("value", $SourceEndPoint)
         $sources.AppendChild($packageSource) | Out-Null
     }
     else {
-        Write-Host "Package source $SourceName already present."
+        Write-Host "Package source $SourceName already present and enabled."
     }
 
     AddCredential -Creds $creds -Source $SourceName -Username $Username -pwd $pwd
@@ -58,6 +67,8 @@ function AddCredential($creds, $source, $username, $pwd) {
     if (!$pwd) {
         return;
     }
+
+    Write-Host "Inserting credential for feed: " $source
 
     # Looks for credential configuration for the given SourceName. Create it if none is found.
     $sourceElement = $creds.SelectSingleNode($Source)
@@ -91,24 +102,27 @@ function AddCredential($creds, $source, $username, $pwd) {
     $passwordElement.SetAttribute("value", $pwd)
 }
 
-function InsertMaestroPrivateFeedCredentials($Sources, $Creds, $Username, $pwd) {
-    $maestroPrivateSources = $Sources.SelectNodes("add[contains(@key,'darc-int')]")
-
-    Write-Host "Inserting credentials for $($maestroPrivateSources.Count) Maestro's private feeds."
-    
-    ForEach ($PackageSource in $maestroPrivateSources) {
-        Write-Host "`tInserting credential for Maestro's feed:" $PackageSource.Key
-        AddCredential -Creds $creds -Source $PackageSource.Key -Username $Username -pwd $pwd
+# Enable all darc-int package sources.
+function EnableMaestroInternalPackageSources($DisabledPackageSources, $Creds) {
+    $maestroInternalSources = $DisabledPackageSources.SelectNodes("add[contains(@key,'darc-int')]")
+    ForEach ($DisabledPackageSource in $maestroInternalSources) {
+        EnableInternalPackageSource -DisabledPackageSources $DisabledPackageSources -Creds $Creds -PackageSourceName $DisabledPackageSource.key
     }
 }
 
-function EnablePrivatePackageSources($DisabledPackageSources) {
-    $maestroPrivateSources = $DisabledPackageSources.SelectNodes("add[contains(@key,'darc-int')]")
-    ForEach ($DisabledPackageSource in $maestroPrivateSources) {
-        Write-Host "`tEnsuring private source '$($DisabledPackageSource.key)' is enabled by deleting it from disabledPackageSource"
+# Enables an internal package source by name, if found. Returns true if the package source was found and enabled, false otherwise.
+function EnableInternalPackageSource($DisabledPackageSources, $Creds, $PackageSourceName) {
+    $DisabledPackageSource = $DisabledPackageSources.SelectSingleNode("add[@key='$PackageSourceName']")
+    if ($DisabledPackageSource) {
+        Write-Host "Enabling internal source '$($DisabledPackageSource.key)'."
+        
         # Due to https://github.com/NuGet/Home/issues/10291, we must actually remove the disabled entries
         $DisabledPackageSources.RemoveChild($DisabledPackageSource)
+
+        AddCredential -Creds $creds -Source $DisabledPackageSource.Key -Username $userName -pwd $Password
+        return $true
     }
+    return $false
 }
 
 if (!(Test-Path $ConfigFile -PathType Leaf)) {
@@ -121,15 +135,17 @@ $doc = New-Object System.Xml.XmlDocument
 $filename = (Get-Item $ConfigFile).FullName
 $doc.Load($filename)
 
-# Get reference to <PackageSources> or create one if none exist already
+# Get reference to <PackageSources> - fail if none exist
 $sources = $doc.DocumentElement.SelectSingleNode("packageSources")
 if ($sources -eq $null) {
-    $sources = $doc.CreateElement("packageSources")
-    $doc.DocumentElement.AppendChild($sources) | Out-Null
+    Write-PipelineTelemetryError -Category 'Build' -Message "Eng/common/SetupNugetSources.ps1 returned a non-zero exit code. NuGet config file must contain a packageSources section: $ConfigFile"
+    ExitWithExitCode 1
 }
 
 $creds = $null
+$feedSuffix = "v3/index.json"
 if ($Password) {
+    $feedSuffix = "v2"
     # Looks for a <PackageSourceCredentials> node. Create it if none is found.
     $creds = $doc.DocumentElement.SelectSingleNode("packageSourceCredentials")
     if ($creds -eq $null) {
@@ -138,33 +154,22 @@ if ($Password) {
     }
 }
 
+$userName = "dn-bot"
+
 # Check for disabledPackageSources; we'll enable any darc-int ones we find there
 $disabledSources = $doc.DocumentElement.SelectSingleNode("disabledPackageSources")
 if ($disabledSources -ne $null) {
     Write-Host "Checking for any darc-int disabled package sources in the disabledPackageSources node"
-    EnablePrivatePackageSources -DisabledPackageSources $disabledSources
+    EnableMaestroInternalPackageSources -DisabledPackageSources $disabledSources -Creds $creds
 }
-
-$userName = "dn-bot"
-
-# Insert credential nodes for Maestro's private feeds
-InsertMaestroPrivateFeedCredentials -Sources $sources -Creds $creds -Username $userName -pwd $Password
-
-# 3.1 uses a different feed url format so it's handled differently here
-$dotnet31Source = $sources.SelectSingleNode("add[@key='dotnet3.1']")
-if ($dotnet31Source -ne $null) {
-    AddPackageSource -Sources $sources -SourceName "dotnet3.1-internal" -SourceEndPoint "https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3.1-internal/nuget/v2" -Creds $creds -Username $userName -pwd $Password
-    AddPackageSource -Sources $sources -SourceName "dotnet3.1-internal-transport" -SourceEndPoint "https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3.1-internal-transport/nuget/v2" -Creds $creds -Username $userName -pwd $Password
-}
-
 $dotnetVersions = @('5','6','7','8','9','10')
 
 foreach ($dotnetVersion in $dotnetVersions) {
     $feedPrefix = "dotnet" + $dotnetVersion;
     $dotnetSource = $sources.SelectSingleNode("add[@key='$feedPrefix']")
     if ($dotnetSource -ne $null) {
-        AddPackageSource -Sources $sources -SourceName "$feedPrefix-internal" -SourceEndPoint "https://pkgs.dev.azure.com/dnceng/internal/_packaging/$feedPrefix-internal/nuget/v2" -Creds $creds -Username $userName -pwd $Password
-        AddPackageSource -Sources $sources -SourceName "$feedPrefix-internal-transport" -SourceEndPoint "https://pkgs.dev.azure.com/dnceng/internal/_packaging/$feedPrefix-internal-transport/nuget/v2" -Creds $creds -Username $userName -pwd $Password
+        AddOrEnablePackageSource -Sources $sources -DisabledPackageSources $disabledSources -SourceName "$feedPrefix-internal" -SourceEndPoint "https://pkgs.dev.azure.com/dnceng/internal/_packaging/$feedPrefix-internal/nuget/$feedSuffix" -Creds $creds -Username $userName -pwd $Password
+        AddOrEnablePackageSource -Sources $sources -DisabledPackageSources $disabledSources -SourceName "$feedPrefix-internal-transport" -SourceEndPoint "https://pkgs.dev.azure.com/dnceng/internal/_packaging/$feedPrefix-internal-transport/nuget/$feedSuffix" -Creds $creds -Username $userName -pwd $Password
     }
 }
 

--- a/eng/common/SetupNugetSources.sh
+++ b/eng/common/SetupNugetSources.sh
@@ -52,78 +52,124 @@ if [[ `uname -s` == "Darwin" ]]; then
     TB=''
 fi
 
+# Enables an internal package source by name, if found. Returns 0 if found and enabled, 1 if not found.
+EnableInternalPackageSource() {
+    local PackageSourceName="$1"
+    
+    # Check if disabledPackageSources section exists
+    grep -i "<disabledPackageSources>" "$ConfigFile" > /dev/null
+    if [ "$?" != "0" ]; then
+        return 1  # No disabled sources section
+    fi
+    
+    # Check if this source name is disabled
+    grep -i "<add key=\"$PackageSourceName\" value=\"true\"" "$ConfigFile" > /dev/null
+    if [ "$?" == "0" ]; then
+        echo "Enabling internal source '$PackageSourceName'."
+        # Remove the disabled entry (including any surrounding comments or whitespace on the same line)
+        sed -i.bak "/<add key=\"$PackageSourceName\" value=\"true\" \/>/d" "$ConfigFile"
+        
+        # Add the source name to PackageSources for credential handling
+        PackageSources+=("$PackageSourceName")
+        return 0  # Found and enabled
+    fi
+    
+    return 1  # Not found in disabled sources
+}
+
+# Add source entry to PackageSources
+AddPackageSource() {
+    local SourceName="$1"
+    local SourceEndPoint="$2"
+    
+    # Check if source already exists
+    grep -i "<add key=\"$SourceName\"" "$ConfigFile" > /dev/null
+    if [ "$?" == "0" ]; then
+        echo "Package source $SourceName already present and enabled."
+        PackageSources+=("$SourceName")
+        return
+    fi
+    
+    echo "Adding package source $SourceName"
+    PackageSourcesNodeFooter="</packageSources>"
+    PackageSourceTemplate="${TB}<add key=\"$SourceName\" value=\"$SourceEndPoint\" />"
+    
+    sed -i.bak "s|$PackageSourcesNodeFooter|$PackageSourceTemplate${NL}$PackageSourcesNodeFooter|" "$ConfigFile"
+    PackageSources+=("$SourceName")
+}
+
+# Adds or enables the package source with the given name
+AddOrEnablePackageSource() {
+    local SourceName="$1"
+    local SourceEndPoint="$2"
+    
+    # Try to enable if disabled, if not found then add new source
+    EnableInternalPackageSource "$SourceName"
+    if [ "$?" != "0" ]; then
+        AddPackageSource "$SourceName" "$SourceEndPoint"
+    fi
+}
+
+# Enable all darc-int package sources
+EnableMaestroInternalPackageSources() {
+    # Check if disabledPackageSources section exists
+    grep -i "<disabledPackageSources>" "$ConfigFile" > /dev/null
+    if [ "$?" != "0" ]; then
+        return  # No disabled sources section
+    fi
+    
+    # Find all darc-int disabled sources
+    local DisabledDarcIntSources=()
+    DisabledDarcIntSources+=$(grep -oh '"darc-int-[^"]*" value="true"' "$ConfigFile" | tr -d '"')
+    
+    for DisabledSourceName in ${DisabledDarcIntSources[@]} ; do
+        if [[ $DisabledSourceName == darc-int* ]]; then
+            EnableInternalPackageSource "$DisabledSourceName"
+        fi
+    done
+}
+
 # Ensure there is a <packageSources>...</packageSources> section.
 grep -i "<packageSources>" $ConfigFile
 if [ "$?" != "0" ]; then
-    echo "Adding <packageSources>...</packageSources> section."
-    ConfigNodeHeader="<configuration>"
-    PackageSourcesTemplate="${TB}<packageSources>${NL}${TB}</packageSources>"
-
-    sed -i.bak "s|$ConfigNodeHeader|$ConfigNodeHeader${NL}$PackageSourcesTemplate|" $ConfigFile
-fi
-
-# Ensure there is a <packageSourceCredentials>...</packageSourceCredentials> section. 
-grep -i "<packageSourceCredentials>" $ConfigFile
-if [ "$?" != "0" ]; then
-    echo "Adding <packageSourceCredentials>...</packageSourceCredentials> section."
-
-    PackageSourcesNodeFooter="</packageSources>"
-    PackageSourceCredentialsTemplate="${TB}<packageSourceCredentials>${NL}${TB}</packageSourceCredentials>"
-
-    sed -i.bak "s|$PackageSourcesNodeFooter|$PackageSourcesNodeFooter${NL}$PackageSourceCredentialsTemplate|" $ConfigFile
+    Write-PipelineTelemetryError -Category 'Build' "Error: Eng/common/SetupNugetSources.sh returned a non-zero exit code. NuGet config file must contain a packageSources section: $ConfigFile"
+    ExitWithExitCode 1
 fi
 
 PackageSources=()
 
-# Ensure dotnet3.1-internal and dotnet3.1-internal-transport are in the packageSources if the public dotnet3.1 feeds are present
-grep -i "<add key=\"dotnet3.1\"" $ConfigFile
+# Set feed suffix based on whether credentials are provided
+FeedSuffix="v3/index.json"
+if [ -n "$CredToken" ]; then
+    FeedSuffix="v2"
+    
+    # Ensure there is a <packageSourceCredentials>...</packageSourceCredentials> section.
+    grep -i "<packageSourceCredentials>" $ConfigFile
+    if [ "$?" != "0" ]; then
+        echo "Adding <packageSourceCredentials>...</packageSourceCredentials> section."
+
+        PackageSourcesNodeFooter="</packageSources>"
+        PackageSourceCredentialsTemplate="${TB}<packageSourceCredentials>${NL}${TB}</packageSourceCredentials>"
+
+        sed -i.bak "s|$PackageSourcesNodeFooter|$PackageSourcesNodeFooter${NL}$PackageSourceCredentialsTemplate|" $ConfigFile
+    fi
+fi
+
+# Check for disabledPackageSources; we'll enable any darc-int ones we find there
+grep -i "<disabledPackageSources>" $ConfigFile > /dev/null
 if [ "$?" == "0" ]; then
-    grep -i "<add key=\"dotnet3.1-internal\"" $ConfigFile
-    if [ "$?" != "0" ]; then
-        echo "Adding dotnet3.1-internal to the packageSources."
-        PackageSourcesNodeFooter="</packageSources>"
-        PackageSourceTemplate="${TB}<add key=\"dotnet3.1-internal\" value=\"https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3.1-internal/nuget/v2\" />"
-
-        sed -i.bak "s|$PackageSourcesNodeFooter|$PackageSourceTemplate${NL}$PackageSourcesNodeFooter|" $ConfigFile
-    fi
-    PackageSources+=('dotnet3.1-internal')
-
-    grep -i "<add key=\"dotnet3.1-internal-transport\">" $ConfigFile
-    if [ "$?" != "0" ]; then
-        echo "Adding dotnet3.1-internal-transport to the packageSources."
-        PackageSourcesNodeFooter="</packageSources>"
-        PackageSourceTemplate="${TB}<add key=\"dotnet3.1-internal-transport\" value=\"https://pkgs.dev.azure.com/dnceng/_packaging/dotnet3.1-internal-transport/nuget/v2\" />"
-
-        sed -i.bak "s|$PackageSourcesNodeFooter|$PackageSourceTemplate${NL}$PackageSourcesNodeFooter|" $ConfigFile
-    fi
-    PackageSources+=('dotnet3.1-internal-transport')
+    echo "Checking for any darc-int disabled package sources in the disabledPackageSources node"
+    EnableMaestroInternalPackageSources
 fi
 
 DotNetVersions=('5' '6' '7' '8' '9' '10')
 
 for DotNetVersion in ${DotNetVersions[@]} ; do
     FeedPrefix="dotnet${DotNetVersion}";
-    grep -i "<add key=\"$FeedPrefix\"" $ConfigFile
+    grep -i "<add key=\"$FeedPrefix\"" $ConfigFile > /dev/null
     if [ "$?" == "0" ]; then
-        grep -i "<add key=\"$FeedPrefix-internal\"" $ConfigFile
-        if [ "$?" != "0" ]; then
-            echo "Adding $FeedPrefix-internal to the packageSources."
-            PackageSourcesNodeFooter="</packageSources>"
-            PackageSourceTemplate="${TB}<add key=\"$FeedPrefix-internal\" value=\"https://pkgs.dev.azure.com/dnceng/internal/_packaging/$FeedPrefix-internal/nuget/v2\" />"
-
-            sed -i.bak "s|$PackageSourcesNodeFooter|$PackageSourceTemplate${NL}$PackageSourcesNodeFooter|" $ConfigFile
-        fi
-        PackageSources+=("$FeedPrefix-internal")
-
-        grep -i "<add key=\"$FeedPrefix-internal-transport\">" $ConfigFile
-        if [ "$?" != "0" ]; then
-            echo "Adding $FeedPrefix-internal-transport to the packageSources."
-            PackageSourcesNodeFooter="</packageSources>"
-            PackageSourceTemplate="${TB}<add key=\"$FeedPrefix-internal-transport\" value=\"https://pkgs.dev.azure.com/dnceng/internal/_packaging/$FeedPrefix-internal-transport/nuget/v2\" />"
-
-            sed -i.bak "s|$PackageSourcesNodeFooter|$PackageSourceTemplate${NL}$PackageSourcesNodeFooter|" $ConfigFile
-        fi
-        PackageSources+=("$FeedPrefix-internal-transport")
+        AddOrEnablePackageSource "$FeedPrefix-internal" "https://pkgs.dev.azure.com/dnceng/internal/_packaging/$FeedPrefix-internal/nuget/$FeedSuffix"
+        AddOrEnablePackageSource "$FeedPrefix-internal-transport" "https://pkgs.dev.azure.com/dnceng/internal/_packaging/$FeedPrefix-internal-transport/nuget/$FeedSuffix"
     fi
 done
 
@@ -139,29 +185,12 @@ if [ "$CredToken" ]; then
         # Check if there is no existing credential for this FeedName
         grep -i "<$FeedName>" $ConfigFile 
         if [ "$?" != "0" ]; then
-            echo "Adding credentials for $FeedName."
+            echo "	Inserting credential for feed: $FeedName"
 
             PackageSourceCredentialsNodeFooter="</packageSourceCredentials>"
-            NewCredential="${TB}${TB}<$FeedName>${NL}<add key=\"Username\" value=\"dn-bot\" />${NL}<add key=\"ClearTextPassword\" value=\"$CredToken\" />${NL}</$FeedName>"
+            NewCredential="${TB}${TB}<$FeedName>${NL}${TB}<add key=\"Username\" value=\"dn-bot\" />${NL}${TB}${TB}<add key=\"ClearTextPassword\" value=\"$CredToken\" />${NL}${TB}${TB}</$FeedName>"
 
             sed -i.bak "s|$PackageSourceCredentialsNodeFooter|$NewCredential${NL}$PackageSourceCredentialsNodeFooter|" $ConfigFile
-        fi
-    done
-fi
-
-# Re-enable any entries in disabledPackageSources where the feed name contains darc-int
-grep -i "<disabledPackageSources>" $ConfigFile
-if [ "$?" == "0" ]; then
-    DisabledDarcIntSources=()
-    echo "Re-enabling any disabled \"darc-int\" package sources in $ConfigFile"
-    DisabledDarcIntSources+=$(grep -oh '"darc-int-[^"]*" value="true"' $ConfigFile  | tr -d '"')
-    for DisabledSourceName in ${DisabledDarcIntSources[@]} ; do
-        if [[ $DisabledSourceName == darc-int* ]]
-            then
-                OldDisableValue="<add key=\"$DisabledSourceName\" value=\"true\" />"
-                NewDisableValue="<!-- Reenabled for build : $DisabledSourceName -->"
-                sed -i.bak "s|$OldDisableValue|$NewDisableValue|" $ConfigFile
-                echo "Neutralized disablePackageSources entry for '$DisabledSourceName'"
         fi
     done
 fi

--- a/eng/common/build.sh
+++ b/eng/common/build.sh
@@ -92,7 +92,7 @@ runtime_source_feed=''
 runtime_source_feed_key=''
 
 properties=()
-while [[ $# > 0 ]]; do
+while [[ $# -gt 0 ]]; do
   opt="$(echo "${1/#--/-}" | tr "[:upper:]" "[:lower:]")"
   case "$opt" in
     -help|-h)

--- a/eng/common/core-templates/job/job.yml
+++ b/eng/common/core-templates/job/job.yml
@@ -19,6 +19,8 @@ parameters:
   # publishing defaults
   artifacts: ''
   enableMicrobuild: false
+  enablePreviewMicrobuild: false
+  microbuildPluginVersion: 'latest'
   enableMicrobuildForMacAndLinux: false
   microbuildUseESRP: true
   enablePublishBuildArtifacts: false
@@ -128,6 +130,8 @@ jobs:
     - template: /eng/common/core-templates/steps/install-microbuild.yml
       parameters:
         enableMicrobuild: ${{ parameters.enableMicrobuild }}
+        enablePreviewMicrobuild: ${{ parameters.enablePreviewMicrobuild }}
+        microbuildPluginVersion: ${{ parameters.microbuildPluginVersion }}
         enableMicrobuildForMacAndLinux: ${{ parameters.enableMicrobuildForMacAndLinux }}
         microbuildUseESRP: ${{ parameters.microbuildUseESRP }}
         continueOnError: ${{ parameters.continueOnError }}
@@ -153,6 +157,8 @@ jobs:
     - template: /eng/common/core-templates/steps/cleanup-microbuild.yml
       parameters:
         enableMicrobuild: ${{ parameters.enableMicrobuild }}
+        enablePreviewMicrobuild: ${{ parameters.enablePreviewMicrobuild }}
+        microbuildPluginVersion: ${{ parameters.microbuildPluginVersion }}
         enableMicrobuildForMacAndLinux: ${{ parameters.enableMicrobuildForMacAndLinux }}
         continueOnError: ${{ parameters.continueOnError }}
 

--- a/eng/common/core-templates/job/publish-build-assets.yml
+++ b/eng/common/core-templates/job/publish-build-assets.yml
@@ -91,8 +91,8 @@ jobs:
       fetchDepth: 3
       clean: true
 
-    - ${{ if eq(parameters.isAssetlessBuild, 'false') }}: 
-      - ${{ if eq(parameters.publishingVersion, 3) }}: 
+    - ${{ if eq(parameters.isAssetlessBuild, 'false') }}:
+      - ${{ if eq(parameters.publishingVersion, 3) }}:
         - task: DownloadPipelineArtifact@2
           displayName: Download Asset Manifests
           inputs:
@@ -117,8 +117,15 @@ jobs:
             flattenFolders: true
           condition: ${{ parameters.condition }}
           continueOnError: ${{ parameters.continueOnError }}
-    
+
     - task: NuGetAuthenticate@1
+
+    # Populate internal runtime variables.
+    - template: /eng/common/templates/steps/enable-internal-sources.yml
+      parameters:
+        legacyCredential: $(dn-bot-dnceng-artifact-feeds-rw)
+
+    - template: /eng/common/templates/steps/enable-internal-runtimes.yml
 
     - task: AzureCLI@2
       displayName: Publish Build Assets
@@ -132,9 +139,12 @@ jobs:
           /p:IsAssetlessBuild=${{ parameters.isAssetlessBuild }}
           /p:MaestroApiEndpoint=https://maestro.dot.net
           /p:OfficialBuildId=$(OfficialBuildId)
+          -runtimeSourceFeed https://ci.dot.net/internal
+          -runtimeSourceFeedKey $(dotnetbuilds-internal-container-read-token-base64)
+
       condition: ${{ parameters.condition }}
       continueOnError: ${{ parameters.continueOnError }}
-    
+
     - task: powershell@2
       displayName: Create ReleaseConfigs Artifact
       inputs:
@@ -162,7 +172,7 @@ jobs:
             artifactName: AssetManifests
             displayName: 'Publish Merged Manifest'
             retryCountOnTaskFailure: 10 # for any logs being locked
-            sbomEnabled: false  # we don't need SBOM for logs
+            sbomEnabled: false # we don't need SBOM for logs
 
     - template: /eng/common/core-templates/steps/publish-build-artifacts.yml
       parameters:
@@ -179,6 +189,11 @@ jobs:
           BARBuildId: ${{ parameters.BARBuildId }}
           PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
           is1ESPipeline: ${{ parameters.is1ESPipeline }}
+          
+      # Darc is targeting 8.0, so make sure it's installed
+      - task: UseDotNet@2
+        inputs:
+          version: 8.0.x
 
       - task: AzureCLI@2
         displayName: Publish Using Darc
@@ -195,9 +210,11 @@ jobs:
             -ArtifactsPublishingAdditionalParameters '${{ parameters.artifactsPublishingAdditionalParameters }}'
             -SymbolPublishingAdditionalParameters '${{ parameters.symbolPublishingAdditionalParameters }}'
             -SkipAssetsPublishing '${{ parameters.isAssetlessBuild }}'
+            -runtimeSourceFeed https://ci.dot.net/internal 
+            -runtimeSourceFeedKey $(dotnetbuilds-internal-container-read-token-base64)
 
     - ${{ if eq(parameters.enablePublishBuildArtifacts, 'true') }}:
       - template: /eng/common/core-templates/steps/publish-logs.yml
         parameters:
           is1ESPipeline: ${{ parameters.is1ESPipeline }}
-          JobLabel: 'Publish_Artifacts_Logs'     
+          JobLabel: 'Publish_Artifacts_Logs'

--- a/eng/common/core-templates/post-build/post-build.yml
+++ b/eng/common/core-templates/post-build/post-build.yml
@@ -1,106 +1,106 @@
 parameters:
-  # Which publishing infra should be used. THIS SHOULD MATCH THE VERSION ON THE BUILD MANIFEST.
-  # Publishing V1 is no longer supported
-  # Publishing V2 is no longer supported
-  # Publishing V3 is the default
-  - name: publishingInfraVersion
-    displayName: Which version of publishing should be used to promote the build definition?
-    type: number
-    default: 3
-    values:
-    - 3
+# Which publishing infra should be used. THIS SHOULD MATCH THE VERSION ON THE BUILD MANIFEST.
+# Publishing V1 is no longer supported
+# Publishing V2 is no longer supported
+# Publishing V3 is the default
+- name: publishingInfraVersion
+  displayName: Which version of publishing should be used to promote the build definition?
+  type: number
+  default: 3
+  values:
+  - 3
 
-  - name: BARBuildId
-    displayName: BAR Build Id
-    type: number
-    default: 0
+- name: BARBuildId
+  displayName: BAR Build Id
+  type: number
+  default: 0
 
-  - name: PromoteToChannelIds
-    displayName: Channel to promote BARBuildId to
-    type: string
-    default: ''
+- name: PromoteToChannelIds
+  displayName: Channel to promote BARBuildId to
+  type: string
+  default: ''
 
-  - name: enableSourceLinkValidation
-    displayName: Enable SourceLink validation
-    type: boolean
-    default: false
+- name: enableSourceLinkValidation
+  displayName: Enable SourceLink validation
+  type: boolean
+  default: false
 
-  - name: enableSigningValidation
-    displayName: Enable signing validation
-    type: boolean
-    default: true
+- name: enableSigningValidation
+  displayName: Enable signing validation
+  type: boolean
+  default: true
 
-  - name: enableSymbolValidation
-    displayName: Enable symbol validation
-    type: boolean
-    default: false
+- name: enableSymbolValidation
+  displayName: Enable symbol validation
+  type: boolean
+  default: false
 
-  - name: enableNugetValidation
-    displayName: Enable NuGet validation
-    type: boolean
-    default: true
-    
-  - name: publishInstallersAndChecksums
-    displayName: Publish installers and checksums
-    type: boolean
-    default: true
-    
-  - name: requireDefaultChannels
-    displayName: Fail the build if there are no default channel(s) registrations for the current build
-    type: boolean
-    default: false
+- name: enableNugetValidation
+  displayName: Enable NuGet validation
+  type: boolean
+  default: true
 
-  - name: SDLValidationParameters
-    type: object
-    default:
-      enable: false
-      publishGdn: false
-      continueOnError: false
-      params: ''
-      artifactNames: ''
-      downloadArtifacts: true
+- name: publishInstallersAndChecksums
+  displayName: Publish installers and checksums
+  type: boolean
+  default: true
 
-  - name: isAssetlessBuild
-    type: boolean
-    displayName: Is Assetless Build
-    default: false
+- name: requireDefaultChannels
+  displayName: Fail the build if there are no default channel(s) registrations for the current build
+  type: boolean
+  default: false
 
-  # These parameters let the user customize the call to sdk-task.ps1 for publishing
-  # symbols & general artifacts as well as for signing validation
-  - name: symbolPublishingAdditionalParameters
-    displayName: Symbol publishing additional parameters
-    type: string
-    default: ''
+- name: SDLValidationParameters
+  type: object
+  default:
+    enable: false
+    publishGdn: false
+    continueOnError: false
+    params: ''
+    artifactNames: ''
+    downloadArtifacts: true
 
-  - name: artifactsPublishingAdditionalParameters
-    displayName: Artifact publishing additional parameters
-    type: string
-    default: ''
+- name: isAssetlessBuild
+  type: boolean
+  displayName: Is Assetless Build
+  default: false
 
-  - name: signingValidationAdditionalParameters
-    displayName: Signing validation additional parameters
-    type: string
-    default: ''
+# These parameters let the user customize the call to sdk-task.ps1 for publishing
+# symbols & general artifacts as well as for signing validation
+- name: symbolPublishingAdditionalParameters
+  displayName: Symbol publishing additional parameters
+  type: string
+  default: ''
 
-  # Which stages should finish execution before post-build stages start
-  - name: validateDependsOn
-    type: object
-    default:
-    - build
+- name: artifactsPublishingAdditionalParameters
+  displayName: Artifact publishing additional parameters
+  type: string
+  default: ''
 
-  - name: publishDependsOn
-    type: object
-    default:
-    - Validate
+- name: signingValidationAdditionalParameters
+  displayName: Signing validation additional parameters
+  type: string
+  default: ''
 
-  # Optional: Call asset publishing rather than running in a separate stage
-  - name: publishAssetsImmediately
-    type: boolean
-    default: false
+# Which stages should finish execution before post-build stages start
+- name: validateDependsOn
+  type: object
+  default:
+  - build
 
-  - name: is1ESPipeline
-    type: boolean
-    default: false
+- name: publishDependsOn
+  type: object
+  default:
+  - Validate
+
+# Optional: Call asset publishing rather than running in a separate stage
+- name: publishAssetsImmediately
+  type: boolean
+  default: false
+
+- name: is1ESPipeline
+  type: boolean
+  default: false
 
 stages:
 - ${{ if or(eq( parameters.enableNugetValidation, 'true'), eq(parameters.enableSigningValidation, 'true'), eq(parameters.enableSourceLinkValidation, 'true'), eq(parameters.SDLValidationParameters.enable, 'true')) }}:
@@ -108,10 +108,10 @@ stages:
     dependsOn: ${{ parameters.validateDependsOn }}
     displayName: Validate Build Assets
     variables:
-      - template: /eng/common/core-templates/post-build/common-variables.yml
-      - template: /eng/common/core-templates/variables/pool-providers.yml
-        parameters:
-          is1ESPipeline: ${{ parameters.is1ESPipeline }}
+    - template: /eng/common/core-templates/post-build/common-variables.yml
+    - template: /eng/common/core-templates/variables/pool-providers.yml
+      parameters:
+        is1ESPipeline: ${{ parameters.is1ESPipeline }}
     jobs:
     - job:
       displayName: NuGet Validation
@@ -134,28 +134,28 @@ stages:
             demands: ImageOverride -equals windows.vs2022.amd64
 
       steps:
-        - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
-          parameters:
-            BARBuildId: ${{ parameters.BARBuildId }}
-            PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
-            is1ESPipeline: ${{ parameters.is1ESPipeline }}
+      - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
+        parameters:
+          BARBuildId: ${{ parameters.BARBuildId }}
+          PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
+          is1ESPipeline: ${{ parameters.is1ESPipeline }}
 
-        - task: DownloadBuildArtifacts@0
-          displayName: Download Package Artifacts
-          inputs:
-            buildType: specific
-            buildVersionToDownload: specific
-            project: $(AzDOProjectName)
-            pipeline: $(AzDOPipelineId)
-            buildId: $(AzDOBuildId)
-            artifactName: PackageArtifacts
-            checkDownloadedFiles: true
+      - task: DownloadBuildArtifacts@0
+        displayName: Download Package Artifacts
+        inputs:
+          buildType: specific
+          buildVersionToDownload: specific
+          project: $(AzDOProjectName)
+          pipeline: $(AzDOPipelineId)
+          buildId: $(AzDOBuildId)
+          artifactName: PackageArtifacts
+          checkDownloadedFiles: true
 
-        - task: PowerShell@2
-          displayName: Validate
-          inputs:
-            filePath: $(System.DefaultWorkingDirectory)/eng/common/post-build/nuget-validation.ps1
-            arguments: -PackagesPath $(Build.ArtifactStagingDirectory)/PackageArtifacts/
+      - task: PowerShell@2
+        displayName: Validate
+        inputs:
+          filePath: $(System.DefaultWorkingDirectory)/eng/common/post-build/nuget-validation.ps1
+          arguments: -PackagesPath $(Build.ArtifactStagingDirectory)/PackageArtifacts/
 
     - job:
       displayName: Signing Validation
@@ -169,54 +169,54 @@ stages:
           os: windows
         # If it's not devdiv, it's dnceng
         ${{ else }}:
-          ${{ if eq(parameters.is1ESPipeline, true) }}:        
+          ${{ if eq(parameters.is1ESPipeline, true) }}:
             name: $(DncEngInternalBuildPool)
             image: 1es-windows-2022
             os: windows
           ${{ else }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals windows.vs2022.amd64          
+            demands: ImageOverride -equals windows.vs2022.amd64
       steps:
-        - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
-          parameters:
-            BARBuildId: ${{ parameters.BARBuildId }}
-            PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
-            is1ESPipeline: ${{ parameters.is1ESPipeline }}
+      - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
+        parameters:
+          BARBuildId: ${{ parameters.BARBuildId }}
+          PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
+          is1ESPipeline: ${{ parameters.is1ESPipeline }}
 
-        - task: DownloadBuildArtifacts@0
-          displayName: Download Package Artifacts
-          inputs:
-            buildType: specific
-            buildVersionToDownload: specific
-            project: $(AzDOProjectName)
-            pipeline: $(AzDOPipelineId)
-            buildId: $(AzDOBuildId)
-            artifactName: PackageArtifacts
-            checkDownloadedFiles: true
+      - task: DownloadBuildArtifacts@0
+        displayName: Download Package Artifacts
+        inputs:
+          buildType: specific
+          buildVersionToDownload: specific
+          project: $(AzDOProjectName)
+          pipeline: $(AzDOPipelineId)
+          buildId: $(AzDOBuildId)
+          artifactName: PackageArtifacts
+          checkDownloadedFiles: true
 
-        # This is necessary whenever we want to publish/restore to an AzDO private feed
-        # Since sdk-task.ps1 tries to restore packages we need to do this authentication here
-        # otherwise it'll complain about accessing a private feed.
-        - task: NuGetAuthenticate@1
-          displayName: 'Authenticate to AzDO Feeds'
+      # This is necessary whenever we want to publish/restore to an AzDO private feed
+      # Since sdk-task.ps1 tries to restore packages we need to do this authentication here
+      # otherwise it'll complain about accessing a private feed.
+      - task: NuGetAuthenticate@1
+        displayName: 'Authenticate to AzDO Feeds'
 
-        # Signing validation will optionally work with the buildmanifest file which is downloaded from
-        # Azure DevOps above.
-        - task: PowerShell@2
-          displayName: Validate
-          inputs:
-            filePath: eng\common\sdk-task.ps1
-            arguments: -task SigningValidation -restore -msbuildEngine vs
-              /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts'
-              /p:SignCheckExclusionsFile='$(System.DefaultWorkingDirectory)/eng/SignCheckExclusionsFile.txt'
-              ${{ parameters.signingValidationAdditionalParameters }}
+      # Signing validation will optionally work with the buildmanifest file which is downloaded from
+      # Azure DevOps above.
+      - task: PowerShell@2
+        displayName: Validate
+        inputs:
+          filePath: eng\common\sdk-task.ps1
+          arguments: -task SigningValidation -restore -msbuildEngine vs
+            /p:PackageBasePath='$(Build.ArtifactStagingDirectory)/PackageArtifacts'
+            /p:SignCheckExclusionsFile='$(System.DefaultWorkingDirectory)/eng/SignCheckExclusionsFile.txt'
+            ${{ parameters.signingValidationAdditionalParameters }}
 
-        - template: /eng/common/core-templates/steps/publish-logs.yml
-          parameters:
-            is1ESPipeline: ${{ parameters.is1ESPipeline }}
-            StageLabel: 'Validation'
-            JobLabel: 'Signing'
-            BinlogToolVersion: $(BinlogToolVersion)
+      - template: /eng/common/core-templates/steps/publish-logs.yml
+        parameters:
+          is1ESPipeline: ${{ parameters.is1ESPipeline }}
+          StageLabel: 'Validation'
+          JobLabel: 'Signing'
+          BinlogToolVersion: $(BinlogToolVersion)
 
     - job:
       displayName: SourceLink Validation
@@ -230,41 +230,41 @@ stages:
           os: windows
         # If it's not devdiv, it's dnceng
         ${{ else }}:
-          ${{ if eq(parameters.is1ESPipeline, true) }}:          
+          ${{ if eq(parameters.is1ESPipeline, true) }}:
             name: $(DncEngInternalBuildPool)
             image: 1es-windows-2022
             os: windows
           ${{ else }}:
             name: $(DncEngInternalBuildPool)
-            demands: ImageOverride -equals windows.vs2022.amd64          
+            demands: ImageOverride -equals windows.vs2022.amd64
       steps:
-        - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
-          parameters:
-            BARBuildId: ${{ parameters.BARBuildId }}
-            PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
-            is1ESPipeline: ${{ parameters.is1ESPipeline }}
+      - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
+        parameters:
+          BARBuildId: ${{ parameters.BARBuildId }}
+          PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
+          is1ESPipeline: ${{ parameters.is1ESPipeline }}
 
-        - task: DownloadBuildArtifacts@0
-          displayName: Download Blob Artifacts
-          inputs:
-            buildType: specific
-            buildVersionToDownload: specific
-            project: $(AzDOProjectName)
-            pipeline: $(AzDOPipelineId)
-            buildId: $(AzDOBuildId)
-            artifactName: BlobArtifacts
-            checkDownloadedFiles: true
+      - task: DownloadBuildArtifacts@0
+        displayName: Download Blob Artifacts
+        inputs:
+          buildType: specific
+          buildVersionToDownload: specific
+          project: $(AzDOProjectName)
+          pipeline: $(AzDOPipelineId)
+          buildId: $(AzDOBuildId)
+          artifactName: BlobArtifacts
+          checkDownloadedFiles: true
 
-        - task: PowerShell@2
-          displayName: Validate
-          inputs:
-            filePath: $(System.DefaultWorkingDirectory)/eng/common/post-build/sourcelink-validation.ps1
-            arguments: -InputPath $(Build.ArtifactStagingDirectory)/BlobArtifacts/ 
-              -ExtractPath $(Agent.BuildDirectory)/Extract/ 
-              -GHRepoName $(Build.Repository.Name) 
-              -GHCommit $(Build.SourceVersion)
-              -SourcelinkCliVersion $(SourceLinkCLIVersion)
-          continueOnError: true
+      - task: PowerShell@2
+        displayName: Validate
+        inputs:
+          filePath: $(System.DefaultWorkingDirectory)/eng/common/post-build/sourcelink-validation.ps1
+          arguments: -InputPath $(Build.ArtifactStagingDirectory)/BlobArtifacts/ 
+            -ExtractPath $(Agent.BuildDirectory)/Extract/ 
+            -GHRepoName $(Build.Repository.Name) 
+            -GHCommit $(Build.SourceVersion)
+            -SourcelinkCliVersion $(SourceLinkCLIVersion)
+        continueOnError: true
 
 - ${{ if ne(parameters.publishAssetsImmediately, 'true') }}:
   - stage: publish_using_darc
@@ -274,10 +274,10 @@ stages:
       dependsOn: ${{ parameters.validateDependsOn }}
     displayName: Publish using Darc
     variables:
-      - template: /eng/common/core-templates/post-build/common-variables.yml
-      - template: /eng/common/core-templates/variables/pool-providers.yml
-        parameters:
-          is1ESPipeline: ${{ parameters.is1ESPipeline }}
+    - template: /eng/common/core-templates/post-build/common-variables.yml
+    - template: /eng/common/core-templates/variables/pool-providers.yml
+      parameters:
+        is1ESPipeline: ${{ parameters.is1ESPipeline }}
     jobs:
     - job:
       displayName: Publish Using Darc
@@ -291,30 +291,40 @@ stages:
           os: windows
         # If it's not devdiv, it's dnceng
         ${{ else }}:
-          ${{ if eq(parameters.is1ESPipeline, true) }}:          
+          ${{ if eq(parameters.is1ESPipeline, true) }}:
             name: NetCore1ESPool-Publishing-Internal
             image: windows.vs2019.amd64
             os: windows
           ${{ else }}:
             name: NetCore1ESPool-Publishing-Internal
-            demands: ImageOverride -equals windows.vs2019.amd64          
+            demands: ImageOverride -equals windows.vs2019.amd64
       steps:
-        - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
-          parameters:
-            BARBuildId: ${{ parameters.BARBuildId }}
-            PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
-            is1ESPipeline: ${{ parameters.is1ESPipeline }}
+      - template: /eng/common/core-templates/post-build/setup-maestro-vars.yml
+        parameters:
+          BARBuildId: ${{ parameters.BARBuildId }}
+          PromoteToChannelIds: ${{ parameters.PromoteToChannelIds }}
+          is1ESPipeline: ${{ parameters.is1ESPipeline }}
 
-        - task: NuGetAuthenticate@1
+      - task: NuGetAuthenticate@1 # Populate internal runtime variables.
 
-        - task: AzureCLI@2
-          displayName: Publish Using Darc
-          inputs:
-            azureSubscription: "Darc: Maestro Production"
-            scriptType: ps
-            scriptLocation: scriptPath
-            scriptPath: $(System.DefaultWorkingDirectory)/eng/common/post-build/publish-using-darc.ps1
-            arguments: >
+      - template: /eng/common/templates/steps/enable-internal-sources.yml
+        parameters:
+          legacyCredential: $(dn-bot-dnceng-artifact-feeds-rw)
+
+      - template: /eng/common/templates/steps/enable-internal-runtimes.yml
+
+      - task: UseDotNet@2
+        inputs:
+          version: 8.0.x
+
+      - task: AzureCLI@2
+        displayName: Publish Using Darc
+        inputs:
+          azureSubscription: "Darc: Maestro Production"
+          scriptType: ps
+          scriptLocation: scriptPath
+          scriptPath: $(System.DefaultWorkingDirectory)/eng/common/post-build/publish-using-darc.ps1
+          arguments: >
               -BuildId $(BARBuildId)
               -PublishingInfraVersion ${{ parameters.publishingInfraVersion }}
               -AzdoToken '$(System.AccessToken)'
@@ -323,3 +333,5 @@ stages:
               -ArtifactsPublishingAdditionalParameters '${{ parameters.artifactsPublishingAdditionalParameters }}'
               -SymbolPublishingAdditionalParameters '${{ parameters.symbolPublishingAdditionalParameters }}'
               -SkipAssetsPublishing '${{ parameters.isAssetlessBuild }}'
+              -runtimeSourceFeed https://ci.dot.net/internal 
+              -runtimeSourceFeedKey $(dotnetbuilds-internal-container-read-token-base64)

--- a/eng/common/core-templates/steps/install-microbuild-impl.yml
+++ b/eng/common/core-templates/steps/install-microbuild-impl.yml
@@ -1,0 +1,34 @@
+parameters:
+  - name: microbuildTaskInputs
+    type: object
+    default: {}
+
+  - name: microbuildEnv
+    type: object
+    default: {}
+
+  - name: enablePreviewMicrobuild
+    type: boolean
+    default: false
+
+  - name: condition
+    type: string
+
+  - name: continueOnError
+    type: boolean
+
+steps:
+- ${{ if eq(parameters.enablePreviewMicrobuild, 'true') }}:
+    - task: MicroBuildSigningPluginPreview@4
+      displayName: Install Preview MicroBuild plugin (Windows)
+      inputs: ${{ parameters.microbuildTaskInputs }}
+      env: ${{ parameters.microbuildEnv }}
+      continueOnError: ${{ parameters.continueOnError }}
+      condition: ${{ parameters.condition }}
+- ${{ else }}:
+  - task: MicroBuildSigningPlugin@4
+    displayName: Install MicroBuild plugin (Windows)
+    inputs: ${{ parameters.microbuildTaskInputs }}
+    env: ${{ parameters.microbuildEnv }}
+    continueOnError: ${{ parameters.continueOnError }}
+    condition: ${{ parameters.condition }}

--- a/eng/common/core-templates/steps/install-microbuild-impl.yml
+++ b/eng/common/core-templates/steps/install-microbuild-impl.yml
@@ -20,14 +20,14 @@ parameters:
 steps:
 - ${{ if eq(parameters.enablePreviewMicrobuild, 'true') }}:
     - task: MicroBuildSigningPluginPreview@4
-      displayName: Install Preview MicroBuild plugin (Windows)
+      displayName: Install Preview MicroBuild plugin
       inputs: ${{ parameters.microbuildTaskInputs }}
       env: ${{ parameters.microbuildEnv }}
       continueOnError: ${{ parameters.continueOnError }}
       condition: ${{ parameters.condition }}
 - ${{ else }}:
   - task: MicroBuildSigningPlugin@4
-    displayName: Install MicroBuild plugin (Windows)
+    displayName: Install MicroBuild plugin
     inputs: ${{ parameters.microbuildTaskInputs }}
     env: ${{ parameters.microbuildEnv }}
     continueOnError: ${{ parameters.continueOnError }}

--- a/eng/common/core-templates/steps/install-microbuild.yml
+++ b/eng/common/core-templates/steps/install-microbuild.yml
@@ -4,6 +4,8 @@ parameters:
   # Enable install tasks for MicroBuild on Mac and Linux
   # Will be ignored if 'enableMicrobuild' is false or 'Agent.Os' is 'Windows_NT'
   enableMicrobuildForMacAndLinux: false
+  # Enable preview version of MB signing plugin
+  enablePreviewMicrobuild: false
   # Determines whether the ESRP service connection information should be passed to the signing plugin.
   # This overlaps with _SignType to some degree. We only need the service connection for real signing.
   # It's important that the service connection not be passed to the MicroBuildSigningPlugin task in this place.
@@ -14,6 +16,8 @@ parameters:
   # Location of the MicroBuild output folder
   # NOTE: There's something that relies on this being in the "default" source directory for tasks such as Signing to work properly.
   microBuildOutputFolder: '$(Build.SourcesDirectory)'
+  # Microbuild version
+  microbuildPluginVersion: 'latest'
 
   continueOnError: false
 
@@ -51,41 +55,45 @@ steps:
     # YAML expansion, and Windows vs. Linux/Mac uses different service connections. However,
     # we can avoid including the MB install step if not enabled at all. This avoids a bunch of
     # extra pipeline authorizations, since most pipelines do not sign on non-Windows.
-    - task: MicroBuildSigningPlugin@4
-      displayName: Install MicroBuild plugin (Windows)
-      inputs:
-        signType: $(_SignType)
-        zipSources: false
-        feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
-        ${{ if eq(parameters.microbuildUseESRP, true) }}:
-          ConnectedServiceName: 'MicroBuild Signing Task (DevDiv)'
-          ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
-            ConnectedPMEServiceName: 6cc74545-d7b9-4050-9dfa-ebefcc8961ea
-          ${{ else }}:
-            ConnectedPMEServiceName: 248d384a-b39b-46e3-8ad5-c2c210d5e7ca
-      env:
-        TeamName: $(_TeamName)
-        MicroBuildOutputFolderOverride: ${{ parameters.microBuildOutputFolder }}
-        SYSTEM_ACCESSTOKEN: $(System.AccessToken)
-      continueOnError: ${{ parameters.continueOnError }}
-      condition: and(succeeded(), eq(variables['Agent.Os'], 'Windows_NT'), in(variables['_SignType'], 'real', 'test'))
-
-    - ${{ if eq(parameters.enableMicrobuildForMacAndLinux, true) }}:
-      - task: MicroBuildSigningPlugin@4
-        displayName: Install MicroBuild plugin (non-Windows)
-        inputs:
+    - template: /eng/common/core-templates/steps/install-microbuild-impl.yml@self
+      parameters:
+        enablePreviewMicrobuild: ${{ parameters.enablePreviewMicrobuild }}
+        microbuildTaskInputs:
           signType: $(_SignType)
           zipSources: false
           feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+          version: ${{ parameters.microbuildPluginVersion }}
           ${{ if eq(parameters.microbuildUseESRP, true) }}:
             ConnectedServiceName: 'MicroBuild Signing Task (DevDiv)'
             ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
-              ConnectedPMEServiceName: beb8cb23-b303-4c95-ab26-9e44bc958d39
+              ConnectedPMEServiceName: 6cc74545-d7b9-4050-9dfa-ebefcc8961ea
             ${{ else }}:
-              ConnectedPMEServiceName: c24de2a5-cc7a-493d-95e4-8e5ff5cad2bc
-        env:
+              ConnectedPMEServiceName: 248d384a-b39b-46e3-8ad5-c2c210d5e7ca
+        microbuildEnv:
           TeamName: $(_TeamName)
           MicroBuildOutputFolderOverride: ${{ parameters.microBuildOutputFolder }}
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         continueOnError: ${{ parameters.continueOnError }}
-        condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'),  eq(variables['_SignType'], 'real'))
+        condition: and(succeeded(), eq(variables['Agent.Os'], 'Windows_NT'), in(variables['_SignType'], 'real', 'test'))
+
+    - ${{ if eq(parameters.enableMicrobuildForMacAndLinux, true) }}:
+      - template: /eng/common/core-templates/steps/install-microbuild-impl.yml@self
+        parameters:
+          enablePreviewMicrobuild: ${{ parameters.enablePreviewMicrobuild }}
+          microbuildTaskInputs:
+            signType: $(_SignType)
+            zipSources: false
+            feedSource: https://dnceng.pkgs.visualstudio.com/_packaging/MicroBuildToolset/nuget/v3/index.json
+            version: ${{ parameters.microbuildPluginVersion }}
+            ${{ if eq(parameters.microbuildUseESRP, true) }}:
+              ConnectedServiceName: 'MicroBuild Signing Task (DevDiv)'
+              ${{ if eq(variables['System.TeamProject'], 'DevDiv') }}:
+                ConnectedPMEServiceName: beb8cb23-b303-4c95-ab26-9e44bc958d39
+              ${{ else }}:
+                ConnectedPMEServiceName: c24de2a5-cc7a-493d-95e4-8e5ff5cad2bc
+          microbuildEnv:
+            TeamName: $(_TeamName)
+            MicroBuildOutputFolderOverride: ${{ parameters.microBuildOutputFolder }}
+            SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+          continueOnError: ${{ parameters.continueOnError }}
+          condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'),  eq(variables['_SignType'], 'real'))

--- a/eng/common/core-templates/steps/install-microbuild.yml
+++ b/eng/common/core-templates/steps/install-microbuild.yml
@@ -13,9 +13,6 @@ parameters:
   # Unfortunately, _SignType can't be used to exclude the use of the service connection in non-real sign scenarios. The
   # variable is not available in template expression. _SignType has a very large proliferation across .NET, so replacing it is tough.
   microbuildUseESRP: true
-  # Location of the MicroBuild output folder
-  # NOTE: There's something that relies on this being in the "default" source directory for tasks such as Signing to work properly.
-  microBuildOutputFolder: '$(Build.SourcesDirectory)'
   # Microbuild version
   microbuildPluginVersion: 'latest'
 
@@ -24,14 +21,16 @@ parameters:
 steps:
   - ${{ if eq(parameters.enableMicrobuild, 'true') }}:
     - ${{ if eq(parameters.enableMicrobuildForMacAndLinux, 'true') }}:
-      # Needed to download the MicroBuild plugin nupkgs on Mac and Linux when nuget.exe is unavailable
+      # Installing .NET 8 is required to use the MicroBuild signing plugin on non-Windows platforms
       - task: UseDotNet@2
         displayName: Install .NET 8.0 SDK for MicroBuild Plugin
         inputs:
           packageType: sdk
           version: 8.0.x
-          installationPath: ${{ parameters.microBuildOutputFolder }}/.dotnet
-          workingDirectory: ${{ parameters.microBuildOutputFolder }}
+          # Installing the SDK in a '.dotnet-microbuild' directory is required for signing.
+          # See target FindDotNetPathForMicroBuild in arcade/src/Microsoft.DotNet.Arcade.Sdk/tools/Sign.proj
+          # Do not remove '.dotnet-microbuild' from the path without changing the corresponding logic.
+          installationPath: $(Agent.TempDirectory)/.dotnet-microbuild
         condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'))
 
     - script: |
@@ -71,7 +70,7 @@ steps:
               ConnectedPMEServiceName: 248d384a-b39b-46e3-8ad5-c2c210d5e7ca
         microbuildEnv:
           TeamName: $(_TeamName)
-          MicroBuildOutputFolderOverride: ${{ parameters.microBuildOutputFolder }}
+          MicroBuildOutputFolderOverride: $(Agent.TempDirectory)/MicroBuild
           SYSTEM_ACCESSTOKEN: $(System.AccessToken)
         continueOnError: ${{ parameters.continueOnError }}
         condition: and(succeeded(), eq(variables['Agent.Os'], 'Windows_NT'), in(variables['_SignType'], 'real', 'test'))
@@ -93,7 +92,7 @@ steps:
                 ConnectedPMEServiceName: c24de2a5-cc7a-493d-95e4-8e5ff5cad2bc
           microbuildEnv:
             TeamName: $(_TeamName)
-            MicroBuildOutputFolderOverride: ${{ parameters.microBuildOutputFolder }}
+            MicroBuildOutputFolderOverride: $(Agent.TempDirectory)/MicroBuild
             SYSTEM_ACCESSTOKEN: $(System.AccessToken)
           continueOnError: ${{ parameters.continueOnError }}
           condition: and(succeeded(), ne(variables['Agent.Os'], 'Windows_NT'),  eq(variables['_SignType'], 'real'))

--- a/eng/common/core-templates/steps/publish-logs.yml
+++ b/eng/common/core-templates/steps/publish-logs.yml
@@ -28,6 +28,8 @@ steps:
     arguments: -InputPath '$(System.DefaultWorkingDirectory)/PostBuildLogs' 
       -BinlogToolVersion ${{parameters.BinlogToolVersion}}
       -TokensFilePath '$(System.DefaultWorkingDirectory)/eng/BinlogSecretsRedactionFile.txt'
+      -runtimeSourceFeed https://ci.dot.net/internal 
+      -runtimeSourceFeedKey $(dotnetbuilds-internal-container-read-token-base64)
       '$(publishing-dnceng-devdiv-code-r-build-re)'
       '$(MaestroAccessToken)'
       '$(dn-bot-all-orgs-artifact-feeds-rw)'

--- a/eng/common/darc-init.sh
+++ b/eng/common/darc-init.sh
@@ -5,7 +5,7 @@ darcVersion=''
 versionEndpoint='https://maestro.dot.net/api/assets/darc-version?api-version=2020-02-20'
 verbosity='minimal'
 
-while [[ $# > 0 ]]; do
+while [[ $# -gt 0 ]]; do
   opt="$(echo "$1" | tr "[:upper:]" "[:lower:]")"
   case "$opt" in
     --darcversion)

--- a/eng/common/dotnet-install.sh
+++ b/eng/common/dotnet-install.sh
@@ -18,7 +18,7 @@ architecture=''
 runtime='dotnet'
 runtimeSourceFeed=''
 runtimeSourceFeedKey=''
-while [[ $# > 0 ]]; do
+while [[ $# -gt 0 ]]; do
   opt="$(echo "$1" | tr "[:upper:]" "[:lower:]")"
   case "$opt" in
     -version|-v)

--- a/eng/common/dotnet.sh
+++ b/eng/common/dotnet.sh
@@ -19,7 +19,7 @@ source $scriptroot/tools.sh
 InitializeDotNetCli true # install
 
 # Invoke acquired SDK with args if they are provided
-if [[ $# > 0 ]]; then
+if [[ $# -gt 0 ]]; then
   __dotnetDir=${_InitializeDotNetCli}
   dotnetPath=${__dotnetDir}/dotnet
   ${dotnetPath} "$@"

--- a/eng/common/internal-feed-operations.sh
+++ b/eng/common/internal-feed-operations.sh
@@ -100,7 +100,7 @@ operation=''
 authToken=''
 repoName=''
 
-while [[ $# > 0 ]]; do
+while [[ $# -gt 0 ]]; do
   opt="$(echo "$1" | tr "[:upper:]" "[:lower:]")"
   case "$opt" in
     --operation)

--- a/eng/common/native/install-dependencies.sh
+++ b/eng/common/native/install-dependencies.sh
@@ -30,6 +30,8 @@ case "$os" in
         elif [ "$ID" = "fedora" ] || [ "$ID" = "rhel" ] || [ "$ID" = "azurelinux" ]; then
             pkg_mgr="$(command -v tdnf 2>/dev/null || command -v dnf)"
             $pkg_mgr install -y cmake llvm lld lldb clang python curl libicu-devel openssl-devel krb5-devel lttng-ust-devel pigz cpio
+        elif [ "$ID" = "amzn" ]; then
+            dnf install -y cmake llvm lld lldb clang python libicu-devel openssl-devel krb5-devel lttng-ust-devel pigz cpio
         elif [ "$ID" = "alpine" ]; then
             apk add build-base cmake bash curl clang llvm-dev lld lldb krb5-dev lttng-ust-dev icu-dev openssl-dev pigz cpio
         else

--- a/eng/common/post-build/nuget-verification.ps1
+++ b/eng/common/post-build/nuget-verification.ps1
@@ -30,7 +30,7 @@
 [CmdletBinding(PositionalBinding = $false)]
 param(
    [string]$NuGetExePath,
-   [string]$PackageSource = "https://api.nuget.org/v3/index.json",
+   [string]$PackageSource = "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json",
    [string]$DownloadPath,
    [Parameter(ValueFromRemainingArguments = $true)]
    [string[]]$args

--- a/eng/common/post-build/publish-using-darc.ps1
+++ b/eng/common/post-build/publish-using-darc.ps1
@@ -7,7 +7,9 @@ param(
   [Parameter(Mandatory=$false)][string] $ArtifactsPublishingAdditionalParameters,
   [Parameter(Mandatory=$false)][string] $SymbolPublishingAdditionalParameters,
   [Parameter(Mandatory=$false)][string] $RequireDefaultChannels,
-  [Parameter(Mandatory=$false)][string] $SkipAssetsPublishing
+  [Parameter(Mandatory=$false)][string] $SkipAssetsPublishing,
+  [Parameter(Mandatory=$false)][string] $runtimeSourceFeed,
+  [Parameter(Mandatory=$false)][string] $runtimeSourceFeedKey
 )
 
 try {

--- a/eng/common/post-build/redact-logs.ps1
+++ b/eng/common/post-build/redact-logs.ps1
@@ -7,7 +7,9 @@ param(
   # File with strings to redact - separated by newlines.
   #  For comments start the line with '# ' - such lines are ignored 
   [Parameter(Mandatory=$false)][string] $TokensFilePath,
-  [Parameter(ValueFromRemainingArguments=$true)][String[]]$TokensToRedact
+  [Parameter(ValueFromRemainingArguments=$true)][String[]]$TokensToRedact,
+  [Parameter(Mandatory=$false)][string] $runtimeSourceFeed,
+  [Parameter(Mandatory=$false)][string] $runtimeSourceFeedKey
 )
 
 try {

--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -9,6 +9,8 @@ Param(
   [switch][Alias('nobl')]$excludeCIBinaryLog,
   [switch]$noWarnAsError,
   [switch] $help,
+  [string] $runtimeSourceFeed = '',
+  [string] $runtimeSourceFeedKey = '',
   [Parameter(ValueFromRemainingArguments=$true)][String[]]$properties
 )
 

--- a/eng/common/sdk-task.ps1
+++ b/eng/common/sdk-task.ps1
@@ -68,7 +68,7 @@ try {
       $GlobalJson.tools | Add-Member -Name "vs" -Value (ConvertFrom-Json "{ `"version`": `"16.5`" }") -MemberType NoteProperty
     }
     if( -not ($GlobalJson.tools.PSObject.Properties.Name -match "xcopy-msbuild" )) {
-      $GlobalJson.tools | Add-Member -Name "xcopy-msbuild" -Value "17.13.0" -MemberType NoteProperty
+      $GlobalJson.tools | Add-Member -Name "xcopy-msbuild" -Value "17.14.16" -MemberType NoteProperty
     }
     if ($GlobalJson.tools."xcopy-msbuild".Trim() -ine "none") {
         $xcopyMSBuildToolsFolder = InitializeXCopyMSBuild $GlobalJson.tools."xcopy-msbuild" -install $true

--- a/eng/common/tools.ps1
+++ b/eng/common/tools.ps1
@@ -394,8 +394,8 @@ function InitializeVisualStudioMSBuild([bool]$install, [object]$vsRequirements =
 
   # If the version of msbuild is going to be xcopied,
   # use this version. Version matches a package here:
-  # https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-eng/NuGet/Microsoft.DotNet.Arcade.MSBuild.Xcopy/versions/17.13.0
-  $defaultXCopyMSBuildVersion = '17.13.0'
+  # https://dev.azure.com/dnceng/public/_artifacts/feed/dotnet-eng/NuGet/Microsoft.DotNet.Arcade.MSBuild.Xcopy/versions/17.14.16
+  $defaultXCopyMSBuildVersion = '17.14.16'
 
   if (!$vsRequirements) {
     if (Get-Member -InputObject $GlobalJson.tools -Name 'vs') {

--- a/eng/performance/Scenarios.Common.props
+++ b/eng/performance/Scenarios.Common.props
@@ -24,7 +24,8 @@
 
   <PropertyGroup Condition="'$(TargetsWindows)' != 'true'">
     <ScenariosDir>$(CorrelationPayloadDirectory)performance/src/scenarios/</ScenariosDir>
-    <HelixPreCommands>$(HelixPreCommands);sudo apt-get update;chmod +x $HELIX_CORRELATION_PAYLOAD/startup/perfcollect</HelixPreCommands>
+    <HelixPreCommands Condition="$(PERFLAB_QUEUE.ToLower().Contains('azurelinux'))">$(HelixPreCommands);sudo tdnf -y update;chmod +x $HELIX_CORRELATION_PAYLOAD/startup/perfcollect</HelixPreCommands>
+    <HelixPreCommands Condition="!$(PERFLAB_QUEUE.ToLower().Contains('azurelinux'))">$(HelixPreCommands);sudo apt-get update;chmod +x $HELIX_CORRELATION_PAYLOAD/startup/perfcollect</HelixPreCommands>
     <HelixPreCommands>$(HelixPreCommands);export PYTHONPATH=$HELIX_CORRELATION_PAYLOAD/scripts:$HELIX_CORRELATION_PAYLOAD</HelixPreCommands>
     <RID>linux-$(Architecture)</RID>
   </PropertyGroup>

--- a/eng/performance/maui_scenarios_android.proj
+++ b/eng/performance/maui_scenarios_android.proj
@@ -16,15 +16,18 @@
     <_MSBuildArgs Condition="'$(RuntimeFlavor)' == 'coreclr'">/p:UseMonoRuntime=false</_MSBuildArgs>
 
     <!-- Mono AOT -->
-    <_MSBuildArgs Condition="'$(CodegenType)' == 'AOT'">$(_MSBuildArgs);/p:RunAOTCompilation=true;/p:AndroidEnableProfiledAot=false</_MSBuildArgs>
+    <_MSBuildArgs Condition="'$(RuntimeFlavor)' == 'mono' and '$(CodegenType)' == 'AOT'">$(_MSBuildArgs);/p:RunAOTCompilation=true;/p:AndroidEnableProfiledAot=false</_MSBuildArgs>
     <!-- CoreCLR JIT -->
-    <_MSBuildArgs Condition="'$(CodegenType)' == 'JIT'">$(_MSBuildArgs);/p:PublishReadyToRun=false;/p:PublishReadyToRunComposite=false</_MSBuildArgs>
+    <_MSBuildArgs Condition="'$(RuntimeFlavor)' == 'coreclr' and '$(CodegenType)' == 'JIT'">$(_MSBuildArgs);/p:PublishReadyToRun=false;/p:PublishReadyToRunComposite=false</_MSBuildArgs>
     <!-- CoreCLR R2R -->
-    <_MSBuildArgs Condition="'$(CodegenType)' == 'R2R'">$(_MSBuildArgs);/p:PublishReadyToRun=true;/p:PublishReadyToRunComposite=false</_MSBuildArgs>
+    <_MSBuildArgs Condition="'$(RuntimeFlavor)' == 'coreclr' and '$(CodegenType)' == 'R2R'">$(_MSBuildArgs);/p:PublishReadyToRun=true;/p:PublishReadyToRunComposite=false</_MSBuildArgs>
     <!-- CoreCLR R2R composite -->
-    <_MSBuildArgs Condition="'$(CodegenType)' == 'R2RComposite'">$(_MSBuildArgs);/p:PublishReadyToRun=true;/p:PublishReadyToRunComposite=true</_MSBuildArgs>
+    <_MSBuildArgs Condition="'$(RuntimeFlavor)' == 'coreclr' and '$(CodegenType)' == 'R2RComposite'">$(_MSBuildArgs);/p:PublishReadyToRun=true;/p:PublishReadyToRunComposite=true</_MSBuildArgs>
     <!-- CoreCLR NativeAOT -->
-    <_MSBuildArgs Condition="'$(CodegenType)' == 'NativeAOT'">$(_MSBuildArgs);/p:PublishAot=true</_MSBuildArgs>
+    <_MSBuildArgs Condition="'$(RuntimeFlavor)' == 'coreclr' and '$(CodegenType)' == 'NativeAOT'">$(_MSBuildArgs);/p:PublishAot=true</_MSBuildArgs>
+    
+    <!-- Debug builds use Fast Deployment by default, which excludes assemblies from the APK. -->
+    <_MSBuildArgs Condition="'$(BuildConfig)' == 'Debug'">$(_MSBuildArgs);/p:EmbedAssembliesIntoApk=true</_MSBuildArgs>
 
     <RunConfigsString>$(RuntimeFlavor)_$(CodegenType)</RunConfigsString>
   </PropertyGroup>
@@ -71,7 +74,7 @@
 
   <ItemGroup>
     <PreparePayloadWorkItem Include="@(MAUIAndroidScenario)">
-      <Command>$(Python) pre.py publish -f $(PERFLAB_Framework)-android -r android-arm64 --self-contained --msbuild=&quot;$(_MSBuildArgs)&quot; --binlog $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)\%(PreparePayloadWorkItem.ScenarioDirectoryName).$(RunConfigsString).binlog -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
+      <Command>$(Python) pre.py publish -f $(PERFLAB_Framework)-android -r android-arm64 --self-contained -c $(BuildConfig) --msbuild=&quot;$(_MSBuildArgs)&quot; --binlog $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)\%(PreparePayloadWorkItem.ScenarioDirectoryName).$(RunConfigsString).binlog -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
       <WorkingDirectory>%(PreparePayloadWorkItem.PayloadDirectory)</WorkingDirectory>
     </PreparePayloadWorkItem>
   </ItemGroup>

--- a/eng/performance/maui_scenarios_ios.proj
+++ b/eng/performance/maui_scenarios_ios.proj
@@ -25,7 +25,10 @@
 
   <Target Name="RemoveDotnetFromCorrelationStaging" BeforeTargets="BeforeTest">
     <Message Text="Removing Dotnet Packs from Correlation Staging" Importance="high" />
-    <RemoveDir Directories="$(CorrelationPayloadDirectory)dotnet\packs" />
+    <RemoveDir Directories="$(CorrelationPayloadDirectory)dotnet/packs" />
+    <!-- Remove scenario build intermediates to reduce payload size (published output is in scenarios_out/) -->
+    <RemoveDir Directories="@(MAUIiOSScenario -> '%(PayloadDirectory)/app/obj')" />
+    <RemoveDir Directories="@(MAUIiOSScenario -> '%(PayloadDirectory)/app/bin')" />
   </Target>
 
   <ItemDefinitionGroup>
@@ -47,6 +50,12 @@
       <IPAName>MauiiOSDefault</IPAName>
       <PackageName>net.dot.mauitesting</PackageName>
     </MAUIiOSScenario>
+    <MAUIiOSScenario Include="Maui iOS Sample Content Template">
+      <ScenarioDirectoryName>mauisamplecontentios</ScenarioDirectoryName>
+      <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
+      <IPAName>MauiSampleContentiOSDefault</IPAName>
+      <PackageName>net.dot.mauisamplecontenttesting</PackageName>
+    </MAUIiOSScenario>
     <MAUIiOSScenario Include="Maui Blazor iOS Default Template">
       <ScenarioDirectoryName>mauiblazorios</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
@@ -57,7 +66,7 @@
 
   <ItemGroup>
     <PreparePayloadWorkItem Include="@(MAUIiOSScenario)">
-      <Command>sudo xcode-select -s /Applications/Xcode_26.2.app; $(Python) pre.py publish -f $(PERFLAB_Framework)-ios --self-contained -c $(BuildConfig) -r ios-arm64 --msbuild=&quot;$(_MSBuildArgs)&quot; --binlog $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)/%(PreparePayloadWorkItem.ScenarioDirectoryName).binlog -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName); cd ../; zip -r %(PreparePayloadWorkItem.ScenarioDirectoryName).zip %(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
+      <Command>sudo xcode-select -s /Applications/Xcode_26.2.app; $(Python) pre.py publish -f $(PERFLAB_Framework)-ios --self-contained -c $(BuildConfig) -r ios-arm64 --msbuild=&quot;$(_MSBuildArgs)&quot; --binlog $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)/%(PreparePayloadWorkItem.ScenarioDirectoryName).binlog -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName); rm -rf app/obj app/bin; cd ../; zip -r %(PreparePayloadWorkItem.ScenarioDirectoryName).zip %(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
       <WorkingDirectory>%(PreparePayloadWorkItem.PayloadDirectory)</WorkingDirectory>
     </PreparePayloadWorkItem>
   </ItemGroup>
@@ -123,6 +132,34 @@
 
             # Testing commands
             $(Python) test.py devicestartup --device-type ios --package-path MauiiOSDefault.app --package-name net.dot.mauitesting --scenario-name "%(Identity)" $(ScenarioArgs)
+            ((result=$?))
+
+            # Post commands
+            $(Python) post.py
+            exit $result
+          ]]>
+        </CustomCommands>
+    </XHarnessAppBundleToTest>
+    <XHarnessAppBundleToTest Include="Device Startup - iOS Maui Sample Content Template">
+      <AppBundlePath>$(ScenariosDir)mauisamplecontentios.zip</AppBundlePath>
+      <WorkItemTimeout>00:15:00</WorkItemTimeout>
+      <TestTarget>ios-device</TestTarget>
+      <CustomCommands>
+        <![CDATA[
+            # PreCommands
+            export XHARNESSPATH=$XHARNESS_CLI_PATH
+            
+            cp -v $HELIX_CORRELATION_PAYLOAD/$(PreparePayloadOutDirectoryName)/mauisamplecontentios/MauiSampleContentiOSDefault.ipa $HELIX_WORKITEM_ROOT/mauisamplecontentios/MauiSampleContentiOSDefault.zip
+            mkdir $HELIX_WORKITEM_ROOT/mauisamplecontentios/pub
+            cp -v $HELIX_CORRELATION_PAYLOAD/$(PreparePayloadOutDirectoryName)/mauisamplecontentios/versions.json $HELIX_WORKITEM_ROOT/mauisamplecontentios/pub/versions.json
+            unzip -d $HELIX_WORKITEM_ROOT/mauisamplecontentios $HELIX_WORKITEM_ROOT/mauisamplecontentios/MauiSampleContentiOSDefault.zip
+            mv $HELIX_WORKITEM_ROOT/mauisamplecontentios/Payload/MauiSampleContentiOSDefault.app $HELIX_WORKITEM_ROOT/mauisamplecontentios/MauiSampleContentiOSDefault.app
+            cp -f embedded.mobileprovision $HELIX_WORKITEM_ROOT/mauisamplecontentios/MauiSampleContentiOSDefault.app
+            cd $HELIX_WORKITEM_ROOT/mauisamplecontentios
+            sign MauiSampleContentiOSDefault.app
+
+            # Testing commands
+            $(Python) test.py devicestartup --device-type ios --package-path MauiSampleContentiOSDefault.app --package-name net.dot.mauisamplecontenttesting --scenario-name "%(Identity)" $(ScenarioArgs)
             ((result=$?))
 
             # Post commands

--- a/eng/performance/maui_scenarios_ios.proj
+++ b/eng/performance/maui_scenarios_ios.proj
@@ -41,8 +41,7 @@
       <IPAName>NetiOSDefault</IPAName>
       <PackageName>com.companyname.NetiOSDefault</PackageName>
     </MAUIiOSScenario>
-    <!-- TODO: Enable Maui iOS Default Template once https://github.com/dotnet/performance/issues/5055 is resolved -->
-    <!-- <MAUIiOSScenario Include="Maui iOS Default Template">
+    <MAUIiOSScenario Include="Maui iOS Default Template">
       <ScenarioDirectoryName>mauiios</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
       <IPAName>MauiiOSDefault</IPAName>
@@ -53,7 +52,7 @@
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
       <IPAName>MauiBlazoriOSDefault</IPAName>
       <PackageName>net.dot.mauiblazortesting</PackageName>
-    </MAUIiOSScenario> -->
+    </MAUIiOSScenario>
   </ItemGroup>
 
   <ItemGroup>
@@ -104,8 +103,7 @@
           ]]>
         </CustomCommands>
     </XHarnessAppBundleToTest>
-    <!-- TODO: Enable Device Startup - iOS Maui Default Template once https://github.com/dotnet/performance/issues/5055 is resolved -->
-    <!-- <XHarnessAppBundleToTest Include="Device Startup - iOS Maui Default Template">
+    <XHarnessAppBundleToTest Include="Device Startup - iOS Maui Default Template">
       <AppBundlePath>$(ScenariosDir)mauiios.zip</AppBundlePath>
       <WorkItemTimeout>00:15:00</WorkItemTimeout>
       <TestTarget>ios-device</TestTarget>
@@ -132,7 +130,7 @@
             exit $result
           ]]>
         </CustomCommands>
-    </XHarnessAppBundleToTest> -->
+    </XHarnessAppBundleToTest>
     <!-- Now also disabled for normal mono runs. (Reenable for mono and native aot once fixed). Tracking issue: https://github.com/dotnet/performance/issues/3148 -->
     <!-- <XHarnessAppBundleToTest Condition="'$(RuntimeFlavor)' == 'mono'" Include="Device Startup - iOS Maui Blazor Default Template">
       <AppBundlePath>$(ScenariosDir)mauiblazorios.zip</AppBundlePath>

--- a/eng/performance/maui_scenarios_ios.proj
+++ b/eng/performance/maui_scenarios_ios.proj
@@ -11,7 +11,16 @@
     <PreparePayloadWorkItemBaseDirectory Condition="'$(TargetsWindows)' == 'true'">$(CorrelationPayloadDirectory)$(PreparePayloadOutDirectoryName)\</PreparePayloadWorkItemBaseDirectory>
     <PreparePayloadWorkItemBaseDirectory Condition="'$(TargetsWindows)' != 'true'">$(CorrelationPayloadDirectory)$(PreparePayloadOutDirectoryName)/</PreparePayloadWorkItemBaseDirectory>
     
-    <NativeAOTCommandProps Condition="'$(RuntimeFlavor)' == 'coreclr'">--nativeaot true</NativeAOTCommandProps>
+    <_MSBuildArgs Condition="'$(RuntimeFlavor)' == 'mono'">/p:UseMonoRuntime=true</_MSBuildArgs>
+    <_MSBuildArgs Condition="'$(RuntimeFlavor)' == 'coreclr'">/p:UseMonoRuntime=false</_MSBuildArgs>
+
+    <!-- Mono FullAOT and CoreCLR R2R are considered as default configurations, so no need for explicit properties -->
+    
+    <!-- CoreCLR Interpreter -->
+    <_MSBuildArgs Condition="'$(RuntimeFlavor)' == 'coreclr' and '$(CodegenType)' == 'Interpreter'">$(_MSBuildArgs);/p:PublishReadyToRun=false</_MSBuildArgs>
+    <!-- CoreCLR NativeAOT -->
+    <_MSBuildArgs Condition="'$(RuntimeFlavor)' == 'coreclr' and '$(CodegenType)' == 'NativeAOT'">$(_MSBuildArgs);/p:PublishAot=true;/p:PublishAotUsingRuntimePack=true</_MSBuildArgs>
+
   </PropertyGroup>
 
   <Target Name="RemoveDotnetFromCorrelationStaging" BeforeTargets="BeforeTest">
@@ -32,7 +41,8 @@
       <IPAName>NetiOSDefault</IPAName>
       <PackageName>com.companyname.NetiOSDefault</PackageName>
     </MAUIiOSScenario>
-    <MAUIiOSScenario Include="Maui iOS Default Template">
+    <!-- TODO: Enable Maui iOS Default Template once https://github.com/dotnet/performance/issues/5055 is resolved -->
+    <!-- <MAUIiOSScenario Include="Maui iOS Default Template">
       <ScenarioDirectoryName>mauiios</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
       <IPAName>MauiiOSDefault</IPAName>
@@ -43,12 +53,12 @@
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
       <IPAName>MauiBlazoriOSDefault</IPAName>
       <PackageName>net.dot.mauiblazortesting</PackageName>
-    </MAUIiOSScenario>
+    </MAUIiOSScenario> -->
   </ItemGroup>
 
   <ItemGroup>
     <PreparePayloadWorkItem Include="@(MAUIiOSScenario)">
-      <Command>sudo xcode-select -s /Applications/Xcode_26.0.1.app; $(Python) pre.py publish -f $(PERFLAB_Framework)-ios --self-contained -c Release -r ios-arm64 $(NativeAOTCommandProps) --binlog $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)/%(PreparePayloadWorkItem.ScenarioDirectoryName).binlog -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName); cd ../; zip -r %(PreparePayloadWorkItem.ScenarioDirectoryName).zip %(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
+      <Command>sudo xcode-select -s /Applications/Xcode_26.1.1.app; $(Python) pre.py publish -f $(PERFLAB_Framework)-ios --self-contained -c Release -r ios-arm64 --msbuild=&quot;$(_MSBuildArgs)&quot; --binlog $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)/%(PreparePayloadWorkItem.ScenarioDirectoryName).binlog -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName); cd ../; zip -r %(PreparePayloadWorkItem.ScenarioDirectoryName).zip %(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
       <WorkingDirectory>%(PreparePayloadWorkItem.PayloadDirectory)</WorkingDirectory>
     </PreparePayloadWorkItem>
   </ItemGroup>
@@ -94,7 +104,8 @@
           ]]>
         </CustomCommands>
     </XHarnessAppBundleToTest>
-    <XHarnessAppBundleToTest Include="Device Startup - iOS Maui Default Template">
+    <!-- TODO: Enable Device Startup - iOS Maui Default Template once https://github.com/dotnet/performance/issues/5055 is resolved -->
+    <!-- <XHarnessAppBundleToTest Include="Device Startup - iOS Maui Default Template">
       <AppBundlePath>$(ScenariosDir)mauiios.zip</AppBundlePath>
       <WorkItemTimeout>00:15:00</WorkItemTimeout>
       <TestTarget>ios-device</TestTarget>
@@ -113,7 +124,7 @@
             sign MauiiOSDefault.app
 
             # Testing commands
-            $(Python) test.py devicestartup --device-type ios --package-path MauiiOSDefault.app --package-name net.dot.mauitesting --scenario-name "%(Identity)" $(ScenarioArgs)
+            $(Python) test.py devicestartup -1-device-type ios -1-package-path MauiiOSDefault.app -1-package-name net.dot.mauitesting -1-scenario-name "%(Identity)" $(ScenarioArgs)
             ((result=$?))
 
             # Post commands
@@ -121,7 +132,7 @@
             exit $result
           ]]>
         </CustomCommands>
-    </XHarnessAppBundleToTest>
+    </XHarnessAppBundleToTest> -->
     <!-- Now also disabled for normal mono runs. (Reenable for mono and native aot once fixed). Tracking issue: https://github.com/dotnet/performance/issues/3148 -->
     <!-- <XHarnessAppBundleToTest Condition="'$(RuntimeFlavor)' == 'mono'" Include="Device Startup - iOS Maui Blazor Default Template">
       <AppBundlePath>$(ScenariosDir)mauiblazorios.zip</AppBundlePath>

--- a/eng/performance/maui_scenarios_ios.proj
+++ b/eng/performance/maui_scenarios_ios.proj
@@ -58,7 +58,7 @@
 
   <ItemGroup>
     <PreparePayloadWorkItem Include="@(MAUIiOSScenario)">
-      <Command>sudo xcode-select -s /Applications/Xcode_26.1.1.app; $(Python) pre.py publish -f $(PERFLAB_Framework)-ios --self-contained -c Release -r ios-arm64 --msbuild=&quot;$(_MSBuildArgs)&quot; --binlog $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)/%(PreparePayloadWorkItem.ScenarioDirectoryName).binlog -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName); cd ../; zip -r %(PreparePayloadWorkItem.ScenarioDirectoryName).zip %(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
+      <Command>sudo xcode-select -s /Applications/Xcode_26.2.app; $(Python) pre.py publish -f $(PERFLAB_Framework)-ios --self-contained -c Release -r ios-arm64 --msbuild=&quot;$(_MSBuildArgs)&quot; --binlog $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)/%(PreparePayloadWorkItem.ScenarioDirectoryName).binlog -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName); cd ../; zip -r %(PreparePayloadWorkItem.ScenarioDirectoryName).zip %(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
       <WorkingDirectory>%(PreparePayloadWorkItem.PayloadDirectory)</WorkingDirectory>
     </PreparePayloadWorkItem>
   </ItemGroup>

--- a/eng/performance/maui_scenarios_ios.proj
+++ b/eng/performance/maui_scenarios_ios.proj
@@ -122,7 +122,7 @@
             sign MauiiOSDefault.app
 
             # Testing commands
-            $(Python) test.py devicestartup -1-device-type ios -1-package-path MauiiOSDefault.app -1-package-name net.dot.mauitesting -1-scenario-name "%(Identity)" $(ScenarioArgs)
+            $(Python) test.py devicestartup --device-type ios --package-path MauiiOSDefault.app --package-name net.dot.mauitesting --scenario-name "%(Identity)" $(ScenarioArgs)
             ((result=$?))
 
             # Post commands

--- a/eng/performance/maui_scenarios_ios.proj
+++ b/eng/performance/maui_scenarios_ios.proj
@@ -57,7 +57,7 @@
 
   <ItemGroup>
     <PreparePayloadWorkItem Include="@(MAUIiOSScenario)">
-      <Command>sudo xcode-select -s /Applications/Xcode_26.2.app; $(Python) pre.py publish -f $(PERFLAB_Framework)-ios --self-contained -c Release -r ios-arm64 --msbuild=&quot;$(_MSBuildArgs)&quot; --binlog $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)/%(PreparePayloadWorkItem.ScenarioDirectoryName).binlog -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName); cd ../; zip -r %(PreparePayloadWorkItem.ScenarioDirectoryName).zip %(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
+      <Command>sudo xcode-select -s /Applications/Xcode_26.2.app; $(Python) pre.py publish -f $(PERFLAB_Framework)-ios --self-contained -c $(BuildConfig) -r ios-arm64 --msbuild=&quot;$(_MSBuildArgs)&quot; --binlog $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)/%(PreparePayloadWorkItem.ScenarioDirectoryName).binlog -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName); cd ../; zip -r %(PreparePayloadWorkItem.ScenarioDirectoryName).zip %(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
       <WorkingDirectory>%(PreparePayloadWorkItem.PayloadDirectory)</WorkingDirectory>
     </PreparePayloadWorkItem>
   </ItemGroup>

--- a/eng/performance/maui_scenarios_ios.proj
+++ b/eng/performance/maui_scenarios_ios.proj
@@ -48,7 +48,7 @@
 
   <ItemGroup>
     <PreparePayloadWorkItem Include="@(MAUIiOSScenario)">
-      <Command>sudo xcode-select -s /Applications/Xcode_26.app; $(Python) pre.py publish -f $(PERFLAB_Framework)-ios --self-contained -c Release -r ios-arm64 $(NativeAOTCommandProps) --binlog $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)/%(PreparePayloadWorkItem.ScenarioDirectoryName).binlog -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName); cd ../; zip -r %(PreparePayloadWorkItem.ScenarioDirectoryName).zip %(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
+      <Command>sudo xcode-select -s /Applications/Xcode_26.0.1.app; $(Python) pre.py publish -f $(PERFLAB_Framework)-ios --self-contained -c Release -r ios-arm64 $(NativeAOTCommandProps) --binlog $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName)/%(PreparePayloadWorkItem.ScenarioDirectoryName).binlog -o $(PreparePayloadWorkItemBaseDirectory)%(PreparePayloadWorkItem.ScenarioDirectoryName); cd ../; zip -r %(PreparePayloadWorkItem.ScenarioDirectoryName).zip %(PreparePayloadWorkItem.ScenarioDirectoryName)</Command>
       <WorkingDirectory>%(PreparePayloadWorkItem.PayloadDirectory)</WorkingDirectory>
     </PreparePayloadWorkItem>
   </ItemGroup>

--- a/eng/performance/scenarios.proj
+++ b/eng/performance/scenarios.proj
@@ -43,11 +43,15 @@
       <ScenarioDirectoryName>windowsformslarge</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
     </UIScenario>
-    <UIScenario Include="WPF Template" Condition="'$(TargetsWindows)' == 'true' AND '$(OS)' == 'Windows_NT'">
+    <!-- WPF Template: limited to internal runs due to CloseFailed on generic CI VMs (same issue as WinForms).
+      Override with /p:IncludeVMFlakyScenarios=true to include on other builds. -->
+    <UIScenario Include="WPF Template" Condition="'$(TargetsWindows)' == 'true' AND '$(OS)' == 'Windows_NT' AND ( '$(SYSTEM_TEAMPROJECT)' == 'internal' OR '$(IncludeVMFlakyScenarios)' == 'true' )">
       <ScenarioDirectoryName>wpf</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
     </UIScenario>
-    <UIScenario Include="WPF SFC" Condition="'$(TargetsWindows)' == 'true' AND '$(OS)' == 'Windows_NT'">
+    <!-- WPF SFC: gated for consistency with WPF Template.
+      Override with /p:IncludeVMFlakyScenarios=true to include on other builds. -->
+    <UIScenario Include="WPF SFC" Condition="'$(TargetsWindows)' == 'true' AND '$(OS)' == 'Windows_NT' AND ( '$(SYSTEM_TEAMPROJECT)' == 'internal' OR '$(IncludeVMFlakyScenarios)' == 'true' )">
       <ScenarioDirectoryName>wpfsfc</ScenarioDirectoryName>
       <PayloadDirectory>$(ScenariosDir)%(ScenarioDirectoryName)</PayloadDirectory>
     </UIScenario>

--- a/eng/performance/sdk_scenarios.proj
+++ b/eng/performance/sdk_scenarios.proj
@@ -12,7 +12,8 @@
       <Framework Include="net7.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '6.0'"/>
       <Framework Include="net8.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '7.0' and '$(PERFLAB_Framework)' != 'net9.0'"/>
       <Framework Include="net9.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '8.0'"/>
-      <Framework Include="net10.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '9.0'"/>
+      <Framework Include="net10.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '9.0' and '$(PERFLAB_Framework)' != 'net11.0'"/>
+      <Framework Include="net11.0" FrameworkName="%(Identity)" Condition="'$(FrameworkVersion)' &gt; '10.0'"/>
   </ItemGroup>
 
   <ItemDefinitionGroup>

--- a/eng/pipelines/runtime-ios-scenarios-perf-jobs.yml
+++ b/eng/pipelines/runtime-ios-scenarios-perf-jobs.yml
@@ -10,28 +10,7 @@ jobs:
       coreclr: true
       nativeAot: true
 
-  # run iOS scenarios - Mono FullAOT
-  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-        - osx_x64
-      jobParameters:
-        runtimeType: iOSMono
-        codeGenType: FullAOT
-        projectFile: $(Build.SourcesDirectory)/eng/testing/performance/ios_scenarios.proj
-        runKind: ios_scenarios
-        isScenario: true
-        logicalMachine: 'perfiphone12mini'
-        iOSLlvmBuild: False
-        iOSStripSymbols: False
-        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
-
+  # run iOS scenarios - Mono FullAOT (no LLVM)
   - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
     parameters:
       jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
@@ -54,28 +33,7 @@ jobs:
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
-  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-        - osx_x64
-      jobParameters:
-        runtimeType: iOSMono
-        codeGenType: FullAOT
-        projectFile: $(Build.SourcesDirectory)/eng/testing/performance/ios_scenarios.proj
-        runKind: ios_scenarios
-        isScenario: true
-        logicalMachine: 'perfiphone12mini'
-        iOSLlvmBuild: True
-        iOSStripSymbols: False
-        additionalJobIdentifier: iOSLlvmBuild
-        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
-
+  # run iOS scenarios - Mono FullAOT (with LLVM)
   - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
     parameters:
       jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
@@ -113,26 +71,6 @@ jobs:
         runKind: ios_scenarios
         isScenario: true
         logicalMachine: 'perfiphone12mini'
-        iOSStripSymbols: False
-        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
-
-  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-        - osx_x64
-      jobParameters:
-        runtimeType: iOSNativeAOT
-        codeGenType: NativeAOT
-        projectFile: $(Build.SourcesDirectory)/eng/testing/performance/ios_scenarios.proj
-        runKind: ios_scenarios
-        isScenario: true
-        logicalMachine: 'perfiphone12mini'
         iOSStripSymbols: True
         additionalJobIdentifier: iOSStripSymbols
         runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
@@ -155,7 +93,8 @@ jobs:
         runKind: ios_scenarios
         isScenario: true
         logicalMachine: 'perfiphone12mini'
-        iOSStripSymbols: false
+        iOSStripSymbols: True
+        additionalJobIdentifier: iOSStripSymbols
         runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
         performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
         ${{ each parameter in parameters.jobParameters }}:

--- a/eng/pipelines/runtime-ios-scenarios-perf-jobs.yml
+++ b/eng/pipelines/runtime-ios-scenarios-perf-jobs.yml
@@ -78,7 +78,7 @@ jobs:
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
-  # run iOS scenarios - CoreCLR
+  # run iOS scenarios - CoreCLR Interpreter
   - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
     parameters:
       jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
@@ -89,6 +89,28 @@ jobs:
       jobParameters:
         runtimeType: iOSCoreCLR
         codeGenType: Interpreter
+        projectFile: $(Build.SourcesDirectory)/eng/testing/performance/ios_scenarios.proj
+        runKind: ios_scenarios
+        isScenario: true
+        logicalMachine: 'perfiphone12mini'
+        iOSStripSymbols: True
+        additionalJobIdentifier: iOSStripSymbols
+        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
+
+  # run iOS scenarios - CoreCLR R2R
+  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+    parameters:
+      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+      buildConfig: release
+      runtimeFlavor: coreclr
+      platforms:
+        - osx_x64
+      jobParameters:
+        runtimeType: iOSCoreCLR
+        codeGenType: R2R
         projectFile: $(Build.SourcesDirectory)/eng/testing/performance/ios_scenarios.proj
         runKind: ios_scenarios
         isScenario: true

--- a/eng/pipelines/runtime-perf-build-jobs.yml
+++ b/eng/pipelines/runtime-perf-build-jobs.yml
@@ -77,3 +77,8 @@ jobs:
     - template: /eng/pipelines/performance/templates/perf-ios-scenarios-build-jobs.yml@${{ parameters.runtimeRepoAlias }}
       parameters:
         nativeAot: true
+
+  - ${{ if containsValue(parameters.buildType, 'coreclr_arm64_ios') }}:
+    - template: /eng/pipelines/performance/templates/perf-ios-scenarios-build-jobs.yml@${{ parameters.runtimeRepoAlias }}
+      parameters:
+        coreclr: true

--- a/eng/pipelines/runtime-perf-jobs.yml
+++ b/eng/pipelines/runtime-perf-jobs.yml
@@ -58,113 +58,114 @@ jobs:
     parameters:
       perfBranch: ${{ parameters.perfBranch }}
 
-  # Build and run iOS Mono and NativeAOT scenarios
-  - template: /eng/pipelines/runtime-ios-scenarios-perf-jobs.yml
-    parameters:
-      runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-      performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-      jobParameters: ${{ parameters.jobParameters }}
-
-  # run android scenarios - Mono JIT
-  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-        - windows_x64
-      jobParameters:
-        runtimeType: AndroidMono
-        codeGenType: JIT
-        projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
-        runKind: android_scenarios
-        isScenario: true
-        logicalMachine: 'perfpixel4a'
+  - ${{ if not(startswith(variables['Build.SourceBranch'], 'refs/heads/release')) }}:
+    # Build and run iOS Mono and NativeAOT scenarios
+    - template: /eng/pipelines/runtime-ios-scenarios-perf-jobs.yml
+      parameters:
         runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
         performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+        jobParameters: ${{ parameters.jobParameters }}
 
-  # run android scenarios - Mono AOT
-  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-      buildConfig: release
-      runtimeFlavor: mono
-      platforms:
-        - windows_x64
-      jobParameters:
-        runtimeType: AndroidMono
-        codeGenType: AOT
-        projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
-        runKind: android_scenarios
-        isScenario: true
-        logicalMachine: 'perfpixel4a'
-        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+    # run android scenarios - Mono JIT
+    - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+      parameters:
+        jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+        buildConfig: release
+        runtimeFlavor: mono
+        platforms:
+          - windows_x64
+        jobParameters:
+          runtimeType: AndroidMono
+          codeGenType: JIT
+          projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
+          runKind: android_scenarios
+          isScenario: true
+          logicalMachine: 'perfpixel4a'
+          runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+          performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+          ${{ each parameter in parameters.jobParameters }}:
+            ${{ parameter.key }}: ${{ parameter.value }}
 
-  # run android scenarios - CoreCLR JIT
-  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-        - windows_x64
-      jobParameters:
-        runtimeType: AndroidCoreCLR
-        codeGenType: JIT
-        projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
-        runKind: android_scenarios
-        isScenario: true
-        logicalMachine: 'perfpixel4a'
-        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+    # run android scenarios - Mono AOT
+    - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+      parameters:
+        jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+        buildConfig: release
+        runtimeFlavor: mono
+        platforms:
+          - windows_x64
+        jobParameters:
+          runtimeType: AndroidMono
+          codeGenType: AOT
+          projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
+          runKind: android_scenarios
+          isScenario: true
+          logicalMachine: 'perfpixel4a'
+          runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+          performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+          ${{ each parameter in parameters.jobParameters }}:
+            ${{ parameter.key }}: ${{ parameter.value }}
 
-  # run android scenarios - CoreCLR JIT Static Linking
-  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-        - windows_x64
-      jobParameters:
-        runtimeType: AndroidCoreCLR
-        codeGenType: JIT
-        linkingType: static
-        projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
-        runKind: android_scenarios
-        isScenario: true
-        logicalMachine: 'perfpixel4a'
-        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+    # run android scenarios - CoreCLR JIT
+    - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+      parameters:
+        jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+        buildConfig: release
+        runtimeFlavor: coreclr
+        platforms:
+          - windows_x64
+        jobParameters:
+          runtimeType: AndroidCoreCLR
+          codeGenType: JIT
+          projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
+          runKind: android_scenarios
+          isScenario: true
+          logicalMachine: 'perfpixel4a'
+          runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+          performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+          ${{ each parameter in parameters.jobParameters }}:
+            ${{ parameter.key }}: ${{ parameter.value }}
 
-  # run android scenarios - CoreCLR R2R
-  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-        - windows_x64
-      jobParameters:
-        runtimeType: AndroidCoreCLR
-        codeGenType: R2R
-        projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
-        runKind: android_scenarios
-        isScenario: true
-        logicalMachine: 'perfpixel4a'
-        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+    # run android scenarios - CoreCLR JIT Static Linking
+    - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+      parameters:
+        jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+        buildConfig: release
+        runtimeFlavor: coreclr
+        platforms:
+          - windows_x64
+        jobParameters:
+          runtimeType: AndroidCoreCLR
+          codeGenType: JIT
+          linkingType: static
+          projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
+          runKind: android_scenarios
+          isScenario: true
+          logicalMachine: 'perfpixel4a'
+          runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+          performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+          ${{ each parameter in parameters.jobParameters }}:
+            ${{ parameter.key }}: ${{ parameter.value }}
+
+    # run android scenarios - CoreCLR R2R
+    - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+      parameters:
+        jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+        buildConfig: release
+        runtimeFlavor: coreclr
+        platforms:
+          - windows_x64
+        jobParameters:
+          runtimeType: AndroidCoreCLR
+          codeGenType: R2R
+          projectFile: $(Build.SourcesDirectory)/eng/testing/performance/android_scenarios.proj
+          runKind: android_scenarios
+          isScenario: true
+          logicalMachine: 'perfpixel4a'
+          runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+          performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+          ${{ each parameter in parameters.jobParameters }}:
+            ${{ parameter.key }}: ${{ parameter.value }}
 
   # run mono microbenchmarks perf job
   - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}

--- a/eng/pipelines/runtime-perf-jobs.yml
+++ b/eng/pipelines/runtime-perf-jobs.yml
@@ -232,7 +232,7 @@ jobs:
       runtimeFlavor: coreclr
       platforms:
       - linux_x64
-      - windows_x64
+      # - windows_x64
       jobParameters:
         liveLibrariesBuildConfig: Release
         runKind: micro

--- a/eng/pipelines/runtime-perf-jobs.yml
+++ b/eng/pipelines/runtime-perf-jobs.yml
@@ -224,24 +224,6 @@ jobs:
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
-  # run coreclr perftiger microbenchmarks perf job
-  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-      buildConfig: release
-      runtimeFlavor: coreclr
-      platforms:
-      - linux_x64
-      # - windows_x64
-      jobParameters:
-        liveLibrariesBuildConfig: Release
-        runKind: micro
-        logicalMachine: 'perftiger'
-        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
-
   # run coreclr perfviper microbenchmarks perf job
   - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
     parameters:

--- a/eng/pipelines/runtime-slow-perf-jobs.yml
+++ b/eng/pipelines/runtime-slow-perf-jobs.yml
@@ -31,6 +31,27 @@ jobs:
           ${{ each parameter in parameters.jobParameters }}:
             ${{ parameter.key }}: ${{ parameter.value }}
 
+    # run arm64 interpreter jobs for mono on perfcobalt
+    - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+      parameters:
+        jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+        buildConfig: release
+        runtimeFlavor: mono
+        platforms:
+        - linux_arm64
+        jobParameters:
+          liveLibrariesBuildConfig: Release
+          runtimeType: mono
+          codeGenType: 'Interpreter'
+          runKind: micro_mono
+          logicalMachine: 'perfcobalt'
+          osDistro: 'azurelinux'
+          timeoutInMinutes: 720
+          runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+          performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+          ${{ each parameter in parameters.jobParameters }}:
+            ${{ parameter.key }}: ${{ parameter.value }}
+
     # run arm64 jit jobs for mono
     - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
       parameters:
@@ -44,6 +65,26 @@ jobs:
           runtimeType: mono
           runKind: micro_mono
           logicalMachine: 'perfampere'
+          timeoutInMinutes: 720
+          runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+          performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+          ${{ each parameter in parameters.jobParameters }}:
+            ${{ parameter.key }}: ${{ parameter.value }}
+
+    # run arm64 jit jobs for mono on perfcobalt
+    - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+      parameters:
+        jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+        buildConfig: release
+        runtimeFlavor: mono
+        platforms:
+        - linux_arm64
+        jobParameters:
+          liveLibrariesBuildConfig: Release
+          runtimeType: mono
+          runKind: micro_mono
+          logicalMachine: 'perfcobalt'
+          osDistro: 'azurelinux'
           timeoutInMinutes: 720
           runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
           performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
@@ -94,6 +135,25 @@ jobs:
           ${{ each parameter in parameters.jobParameters }}:
             ${{ parameter.key }}: ${{ parameter.value }}
 
+    # run coreclr Linux arm64 cobalt microbenchmarks perf job
+    - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+      parameters:
+        jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+        buildConfig: release
+        runtimeFlavor: coreclr
+        platforms:
+        - linux_arm64
+        jobParameters:
+          liveLibrariesBuildConfig: Release
+          runKind: micro
+          logicalMachine: 'perfcobalt'
+          osDistro: 'azurelinux'
+          timeoutInMinutes: 780
+          runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+          performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+          ${{ each parameter in parameters.jobParameters }}:
+            ${{ parameter.key }}: ${{ parameter.value }}
+
     # run coreclr Windows arm64 ampere microbenchmarks perf job
     - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
       parameters:
@@ -111,25 +171,3 @@ jobs:
           performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
           ${{ each parameter in parameters.jobParameters }}:
             ${{ parameter.key }}: ${{ parameter.value }}
-
-    # Uncomment once we fix https://github.com/dotnet/performance/issues/1950
-    - ${{ if false }}:
-      # run coreclr linux crossgen perf job
-      - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-        parameters:
-          jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-          buildConfig: release
-          runtimeFlavor: coreclr
-          platforms:
-          - linux_arm64
-          jobParameters:
-            liveLibrariesBuildConfig: Release
-            projectFile: $(Build.SourcesDirectory)/eng/testing/performance/crossgen_perf.proj
-            runKind: crossgen_scenarios
-            isScenario: true
-            logicalMachine: 'perfa64'
-            runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-            performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-            ${{ each parameter in parameters.jobParameters }}:
-              ${{ parameter.key }}: ${{ parameter.value }}
-

--- a/eng/pipelines/runtime-slow-perf-jobs.yml
+++ b/eng/pipelines/runtime-slow-perf-jobs.yml
@@ -31,27 +31,6 @@ jobs:
           ${{ each parameter in parameters.jobParameters }}:
             ${{ parameter.key }}: ${{ parameter.value }}
 
-    # run arm64 interpreter jobs for mono on perfcobalt
-    - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-      parameters:
-        jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-        buildConfig: release
-        runtimeFlavor: mono
-        platforms:
-        - linux_arm64
-        jobParameters:
-          liveLibrariesBuildConfig: Release
-          runtimeType: mono
-          codeGenType: 'Interpreter'
-          runKind: micro_mono
-          logicalMachine: 'perfcobalt'
-          osDistro: 'azurelinux'
-          timeoutInMinutes: 720
-          runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-          performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-          ${{ each parameter in parameters.jobParameters }}:
-            ${{ parameter.key }}: ${{ parameter.value }}
-
     # run arm64 jit jobs for mono
     - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
       parameters:
@@ -65,26 +44,6 @@ jobs:
           runtimeType: mono
           runKind: micro_mono
           logicalMachine: 'perfampere'
-          timeoutInMinutes: 720
-          runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-          performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-          ${{ each parameter in parameters.jobParameters }}:
-            ${{ parameter.key }}: ${{ parameter.value }}
-
-    # run arm64 jit jobs for mono on perfcobalt
-    - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-      parameters:
-        jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-        buildConfig: release
-        runtimeFlavor: mono
-        platforms:
-        - linux_arm64
-        jobParameters:
-          liveLibrariesBuildConfig: Release
-          runtimeType: mono
-          runKind: micro_mono
-          logicalMachine: 'perfcobalt'
-          osDistro: 'azurelinux'
           timeoutInMinutes: 720
           runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
           performanceRepoAlias: ${{ parameters.performanceRepoAlias }}

--- a/eng/pipelines/runtime-wasm-perf-jobs.yml
+++ b/eng/pipelines/runtime-wasm-perf-jobs.yml
@@ -108,24 +108,25 @@ jobs:
             ${{ parameter.key }}: ${{ parameter.value }}
 
   # run mono wasm blazor perf job
-  - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
-    parameters:
-      jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
-      buildConfig: release
-      runtimeFlavor: wasm
-      platforms:
-      - linux_x64
-      jobParameters:
-        liveLibrariesBuildConfig: Release
-        runtimeType: wasm
-        projectFile: $(Build.SourcesDirectory)/eng/testing/performance/blazor_perf.proj
-        runKind: blazor_scenarios
-        isScenario: true
-        # For working with a newer sdk, and previous tfm (eg. 9.0 sdk, and net8.0 tfm)
-        #additionalSetupParameters: '--dotnetversions 8.0.0' # passed to run-performance-job.py
-        logicalMachine: 'perfviper'
-        downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
-        runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
-        performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
+  - ${{ if false }}: # Disabled for now due to https://github.com/dotnet/aspnetcore/issues/64450, reenable tracking issue https://github.com/dotnet/performance/issues/5057
+    - template: /eng/pipelines/common/platform-matrix.yml@${{ parameters.runtimeRepoAlias }}
+      parameters:
+        jobTemplate: /eng/pipelines/templates/runtime-perf-job.yml@${{ parameters.performanceRepoAlias }}
+        buildConfig: release
+        runtimeFlavor: wasm
+        platforms:
+        - linux_x64
+        jobParameters:
+          liveLibrariesBuildConfig: Release
+          runtimeType: wasm
+          projectFile: $(Build.SourcesDirectory)/eng/testing/performance/blazor_perf.proj
+          runKind: blazor_scenarios
+          isScenario: true
+          # For working with a newer sdk, and previous tfm (eg. 9.0 sdk, and net8.0 tfm)
+          #additionalSetupParameters: '--dotnetversions 8.0.0' # passed to run-performance-job.py
+          logicalMachine: 'perfviper'
+          downloadSpecificBuild: ${{ parameters.downloadSpecificBuild }}
+          runtimeRepoAlias: ${{ parameters.runtimeRepoAlias }}
+          performanceRepoAlias: ${{ parameters.performanceRepoAlias }}
+          ${{ each parameter in parameters.jobParameters }}:
+            ${{ parameter.key }}: ${{ parameter.value }}

--- a/eng/pipelines/sdk-perf-jobs.yml
+++ b/eng/pipelines/sdk-perf-jobs.yml
@@ -333,7 +333,7 @@ jobs:
       buildMachines:
         - win-x64-viper
         - ubuntu-x64-viper
-        - win-arm64
+        - win-arm64-ampere
         - ubuntu-arm64-ampere
       isPublic: false
       jobParameters:
@@ -352,7 +352,6 @@ jobs:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
         - win-x64-viper
-        - win-arm64
         - win-arm64-ampere
       isPublic: false
       jobParameters:
@@ -547,7 +546,7 @@ jobs:
         buildMachines:
           - win-x64-viper
           - ubuntu-x64-viper
-          - win-arm64
+          - win-arm64-ampere
           - ubuntu-arm64-ampere
         isPublic: false
         jobParameters:
@@ -567,7 +566,7 @@ jobs:
       buildMachines:
         - win-x64-viper
         - ubuntu-x64-viper
-        - win-arm64
+        - win-arm64-ampere
       isPublic: false
       jobParameters:
         runKind: nativeaot_scenarios
@@ -630,7 +629,7 @@ jobs:
         buildMachines:
           - win-x64-viper
           - ubuntu-x64-viper
-          - win-arm64
+          - win-arm64-ampere
           - ubuntu-arm64-ampere
         isPublic: false
         jobParameters:
@@ -650,7 +649,7 @@ jobs:
       buildMachines:
         - win-x64-viper
         - ubuntu-x64-viper
-        - win-arm64
+        - win-arm64-ampere
         - ubuntu-arm64-ampere
       isPublic: false
       jobParameters:
@@ -671,7 +670,7 @@ jobs:
       buildMachines:
         - win-x64-viper
         - ubuntu-x64-viper
-        - win-arm64
+        - win-arm64-ampere
         - ubuntu-arm64-ampere
       isPublic: false
       jobParameters:
@@ -692,7 +691,7 @@ jobs:
       buildMachines:
         - win-x64-viper
         - ubuntu-x64-viper
-        - win-arm64
+        - win-arm64-ampere
         - ubuntu-arm64-ampere
       isPublic: false
       jobParameters:
@@ -713,7 +712,7 @@ jobs:
       buildMachines:
         - win-x64-viper
         - ubuntu-x64-viper
-        - win-arm64
+        - win-arm64-ampere
         - ubuntu-arm64-ampere
       isPublic: false
       jobParameters:
@@ -733,7 +732,6 @@ jobs:
       buildMachines:
         - win-x64-viper
         - ubuntu-x64-viper
-        - win-arm64
         - win-arm64-ampere
         - ubuntu-arm64-ampere
       isPublic: false
@@ -760,7 +758,6 @@ jobs:
       buildMachines:
         - win-x64-viper
         - ubuntu-x64-viper
-        - win-arm64
         - win-arm64-ampere
         - ubuntu-arm64-ampere
       isPublic: false
@@ -807,8 +804,8 @@ jobs:
       buildMachines:
         - win-x64-viper
         - ubuntu-x64-viper
-        - win-arm64
-        - ubuntu-arm64
+        - win-arm64-ampere
+        - ubuntu-arm64-ampere
       isPublic: false
       jobParameters:
         runKind: powershell

--- a/eng/pipelines/sdk-perf-jobs.yml
+++ b/eng/pipelines/sdk-perf-jobs.yml
@@ -370,7 +370,7 @@ jobs:
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
-  # Maui Android scenario benchmarks (Mono ProfiledAOT)
+  # Maui Android scenario benchmarks (Mono ProfiledAOT) - Release
   - template: /eng/pipelines/templates/build-machine-matrix.yml
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
@@ -385,30 +385,12 @@ jobs:
           - main
         runtimeFlavor: mono
         codeGenType: ProfiledAOT
+        buildConfig: Release
         additionalJobIdentifier: Mono
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
-  # Maui Android scenario benchmarks (Mono AOT)
-  - template: /eng/pipelines/templates/build-machine-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-      buildMachines:
-        - win-x64-android-arm64-pixel
-        - win-x64-android-arm64-galaxy
-      isPublic: false
-      jobParameters:
-        runKind: maui_scenarios_android
-        projectFileName: maui_scenarios_android.proj
-        channels:
-          - main
-        runtimeFlavor: mono
-        codeGenType: AOT
-        additionalJobIdentifier: Mono
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
-
-  # Maui Android scenario benchmarks (CoreCLR JIT)
+  # Maui Android scenario benchmarks (CoreCLR JIT) - Release
   - template: /eng/pipelines/templates/build-machine-matrix.yml
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
@@ -423,11 +405,12 @@ jobs:
           - main
         runtimeFlavor: coreclr
         codeGenType: JIT
+        buildConfig: Release
         additionalJobIdentifier: CoreCLR
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
-  # Maui Android scenario benchmarks (CoreCLR R2R)
+  # Maui Android scenario benchmarks (CoreCLR R2R) - Release
   - template: /eng/pipelines/templates/build-machine-matrix.yml
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
@@ -442,11 +425,12 @@ jobs:
           - main
         runtimeFlavor: coreclr
         codeGenType: R2R
+        buildConfig: Release
         additionalJobIdentifier: CoreCLR
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
-  # Maui Android scenario benchmarks (CoreCLR R2R Composite)
+  # Maui Android scenario benchmarks (CoreCLR R2R Composite) - Release
   - template: /eng/pipelines/templates/build-machine-matrix.yml
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
@@ -461,11 +445,12 @@ jobs:
           - main
         runtimeFlavor: coreclr
         codeGenType: R2RComposite
+        buildConfig: Release
         additionalJobIdentifier: CoreCLR
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
-  # Maui Android scenario benchmarks (CoreCLR NativeAOT)
+  # Maui Android scenario benchmarks (CoreCLR NativeAOT) - Release
   - template: /eng/pipelines/templates/build-machine-matrix.yml
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
@@ -480,11 +465,12 @@ jobs:
           - main
         runtimeFlavor: coreclr
         codeGenType: NativeAOT
+        buildConfig: Release
         additionalJobIdentifier: CoreCLR
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
-  # Maui iOS Mono scenario benchmarks
+  # Maui iOS scenario benchmarks (Mono FullAOT) - Release
   - template: /eng/pipelines/templates/build-machine-matrix.yml
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
@@ -498,11 +484,12 @@ jobs:
           - main
         runtimeFlavor: mono
         codeGenType: FullAOT
+        buildConfig: Release
         additionalJobIdentifier: Mono
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
-  # Maui iOS CoreCLR scenario benchmarks
+  # Maui iOS scenario benchmarks (CoreCLR Interpreter) - Release
   - template: /eng/pipelines/templates/build-machine-matrix.yml
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
@@ -516,11 +503,12 @@ jobs:
           - main
         runtimeFlavor: coreclr
         codeGenType: Interpreter
+        buildConfig: Release
         additionalJobIdentifier: CoreCLR
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
-  # Maui iOS Native AOT scenario benchmarks
+  # Maui iOS scenario benchmarks (CoreCLR NativeAOT) - Release
   - template: /eng/pipelines/templates/build-machine-matrix.yml
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
@@ -534,7 +522,86 @@ jobs:
           - main
         runtimeFlavor: coreclr
         codeGenType: NativeAOT
+        buildConfig: Release
         additionalJobIdentifier: CoreCLR
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
+
+  # Maui Android scenario benchmarks (Mono - Default) - Debug
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+      buildMachines:
+        - win-x64-android-arm64-pixel
+        - win-x64-android-arm64-galaxy
+      isPublic: false
+      jobParameters:
+        runKind: maui_scenarios_android
+        projectFileName: maui_scenarios_android.proj
+        channels:
+          - main
+        runtimeFlavor: mono
+        codeGenType: Default
+        buildConfig: Debug
+        additionalJobIdentifier: Mono_Debug
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
+
+  # Maui Android scenario benchmarks (CoreCLR - Default) - Debug
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+      buildMachines:
+        - win-x64-android-arm64-pixel
+        - win-x64-android-arm64-galaxy
+      isPublic: false
+      jobParameters:
+        runKind: maui_scenarios_android
+        projectFileName: maui_scenarios_android.proj
+        channels:
+          - main
+        runtimeFlavor: coreclr
+        codeGenType: Default
+        buildConfig: Debug
+        additionalJobIdentifier: CoreCLR_Debug
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
+
+  # Maui iOS scenario benchmarks (Mono - Default) - Debug
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+      buildMachines:
+        - osx-x64-ios-arm64
+      isPublic: false
+      jobParameters:
+        runKind: maui_scenarios_ios
+        projectFileName: maui_scenarios_ios.proj
+        channels:
+          - main
+        runtimeFlavor: mono
+        codeGenType: Default
+        buildConfig: Debug
+        additionalJobIdentifier: Mono_Debug
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
+    
+  # Maui iOS scenario benchmarks (CoreCLR - Default) - Debug
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+      buildMachines:
+        - osx-x64-ios-arm64
+      isPublic: false
+      jobParameters:
+        runKind: maui_scenarios_ios
+        projectFileName: maui_scenarios_ios.proj
+        channels:
+          - main
+        runtimeFlavor: coreclr
+        codeGenType: Default
+        buildConfig: Debug
+        additionalJobIdentifier: CoreCLR_Debug
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 

--- a/eng/pipelines/sdk-perf-jobs.yml
+++ b/eng/pipelines/sdk-perf-jobs.yml
@@ -32,6 +32,7 @@ jobs:
         projectFileName: scenarios.proj
         channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
           - main
+          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -51,6 +52,7 @@ jobs:
           projectFileName: maui_scenarios.proj
           channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
             - main
+            - 10.0
             - 9.0
             - 8.0
           ${{ each parameter in parameters.jobParameters }}:
@@ -69,6 +71,7 @@ jobs:
         projectFileName: blazor_scenarios.proj
         channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
           - main
+          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -88,6 +91,7 @@ jobs:
         projectFileName: sdk_scenarios.proj
         channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
           - main
+          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -107,6 +111,7 @@ jobs:
         runCategories: 'runtime libraries' 
         channels:
           - main
+          - 10.0
           - 9.0
           - 8.0
 
@@ -125,6 +130,7 @@ jobs:
           - main
           # - nativeaot9.0 # Disable until I have time to properly fix the issues and can merge https://github.com/dotnet/performance/pull/4741
           # - nativeaot8.0
+          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -144,6 +150,7 @@ jobs:
         runCategories: 'mldotnet' 
         channels:
           - main
+          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -164,6 +171,7 @@ jobs:
           runCategories: 'fsharp'
           channels:
             - main
+            - 10.0
             - 9.0
             - 8.0
           ${{ each parameter in parameters.jobParameters }}:
@@ -182,6 +190,7 @@ jobs:
         runCategories: 'FSharpMicro'
         channels:
           - main
+          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -201,6 +210,7 @@ jobs:
         runCategories: 'BepuPhysics'
         channels:
           - main
+          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -220,6 +230,7 @@ jobs:
         runCategories: 'ImageSharp'
         channels:
           - main
+          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -239,6 +250,7 @@ jobs:
         runCategories: 'AkadeIndexedSet'
         channels:
           - main
+          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -258,6 +270,7 @@ jobs:
         runCategories: 'roslyn'
         channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
           - main
+          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -279,6 +292,7 @@ jobs:
           runCategories: 'illink'
           channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
             - main
+            - 10.0
             - 9.0
             - 8.0
           ${{ each parameter in parameters.jobParameters }}:
@@ -297,6 +311,7 @@ jobs:
         projectFileName: nativeaot_scenarios.proj
         channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
           - main
+          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -316,6 +331,7 @@ jobs:
         runCategories: 'Public'
         channels:
           - main
+          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -344,6 +360,7 @@ jobs:
         projectFileName: scenarios.proj
         channels:
           - main
+          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -364,6 +381,7 @@ jobs:
         projectFileName: scenarios_affinitized.proj
         channels:
           - main
+          - 10.0
           - 9.0
           - 8.0
         additionalJobIdentifier: 'Affinity_85'
@@ -561,6 +579,7 @@ jobs:
           projectFileName: maui_scenarios.proj
           channels:
             - main
+            - 10.0
             - 9.0
             - 8.0
           ${{ each parameter in parameters.jobParameters }}:
@@ -582,6 +601,7 @@ jobs:
         projectFileName: nativeaot_scenarios.proj
         channels:
           - main
+          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -610,6 +630,7 @@ jobs:
         projectFileName: sdk_scenarios.proj
         channels:
           - main
+          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -628,6 +649,7 @@ jobs:
         projectFileName: blazor_scenarios.proj
         channels:
           - main
+          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -652,6 +674,7 @@ jobs:
           runCategories: 'fsharp'
           channels:
             - main
+            - 10.0
             - 9.0
             - 8.0
           ${{ each parameter in parameters.jobParameters }}:
@@ -674,6 +697,7 @@ jobs:
         runCategories: 'FSharpMicro'
         channels:
           - main
+          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -697,6 +721,7 @@ jobs:
         runCategories: 'BepuPhysics'
         channels:
           - main
+          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -720,6 +745,7 @@ jobs:
         runCategories: 'ImageSharp'
         channels:
           - main
+          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -743,6 +769,7 @@ jobs:
         runCategories: 'AkadeIndexedSet'
         channels:
           - main
+          - 10.0
           - 9.0
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
@@ -766,6 +793,7 @@ jobs:
         runCategories: 'mldotnet'
         channels:
           - main
+          - 10.0
           - 9.0
           - 8.0
         affinity: '85' # (01010101) Enables alternating process threads to take hyperthreading into account
@@ -795,6 +823,7 @@ jobs:
         runCategories: 'roslyn'
         channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
           - main
+          - 10.0
           - 9.0
           - 8.0
         affinity: '85' # (01010101) Enables alternating process threads to take hyperthreading into account
@@ -824,6 +853,7 @@ jobs:
           runCategories: 'illink'
           channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
             - main
+            - 10.0
             - 9.0
             - 8.0
 
@@ -845,6 +875,7 @@ jobs:
         runCategories: 'Public Internal'
         channels:
           - main
+          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:

--- a/eng/pipelines/sdk-perf-jobs.yml
+++ b/eng/pipelines/sdk-perf-jobs.yml
@@ -489,7 +489,7 @@ jobs:
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
-  # Maui iOS scenario benchmarks (CoreCLR Interpreter) - Release
+  # Maui iOS scenario benchmarks (CoreCLR Default) - Release
   - template: /eng/pipelines/templates/build-machine-matrix.yml
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
@@ -502,7 +502,7 @@ jobs:
         channels:
           - main
         runtimeFlavor: coreclr
-        codeGenType: Interpreter
+        codeGenType: Default
         buildConfig: Release
         additionalJobIdentifier: CoreCLR
         ${{ each parameter in parameters.jobParameters }}:

--- a/eng/pipelines/sdk-perf-jobs.yml
+++ b/eng/pipelines/sdk-perf-jobs.yml
@@ -32,7 +32,6 @@ jobs:
         projectFileName: scenarios.proj
         channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -52,7 +51,6 @@ jobs:
           projectFileName: maui_scenarios.proj
           channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
             - main
-            - 10.0
             - 9.0
             - 8.0
           ${{ each parameter in parameters.jobParameters }}:
@@ -71,7 +69,6 @@ jobs:
         projectFileName: blazor_scenarios.proj
         channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -90,7 +87,6 @@ jobs:
         projectFileName: sdk_scenarios.proj
         channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -110,7 +106,6 @@ jobs:
         runCategories: 'runtime libraries' 
         channels:
           - main
-          - 10.0
           - 9.0
           - 8.0
 
@@ -129,7 +124,6 @@ jobs:
           - main
           # - nativeaot9.0 # Disable until I have time to properly fix the issues and can merge https://github.com/dotnet/performance/pull/4741
           # - nativeaot8.0
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -149,7 +143,6 @@ jobs:
         runCategories: 'mldotnet' 
         channels:
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -170,7 +163,6 @@ jobs:
           runCategories: 'fsharp'
           channels:
             - main
-            - 10.0
             - 9.0
             - 8.0
           ${{ each parameter in parameters.jobParameters }}:
@@ -189,7 +181,6 @@ jobs:
         runCategories: 'FSharpMicro'
         channels:
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -209,7 +200,6 @@ jobs:
         runCategories: 'BepuPhysics'
         channels:
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -229,7 +219,6 @@ jobs:
         runCategories: 'ImageSharp'
         channels:
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -249,7 +238,6 @@ jobs:
         runCategories: 'AkadeIndexedSet'
         channels:
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -269,7 +257,6 @@ jobs:
         runCategories: 'roslyn'
         channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -291,7 +278,6 @@ jobs:
           runCategories: 'illink'
           channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
             - main
-            - 10.0
             - 9.0
             - 8.0
           ${{ each parameter in parameters.jobParameters }}:
@@ -310,7 +296,6 @@ jobs:
         projectFileName: nativeaot_scenarios.proj
         channels: # for public jobs we want to make sure that the PRs don't break any of the supported frameworks
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -330,7 +315,6 @@ jobs:
         runCategories: 'Public'
         channels:
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -357,7 +341,6 @@ jobs:
         projectFileName: scenarios.proj
         channels:
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -377,7 +360,6 @@ jobs:
         projectFileName: scenarios_affinitized.proj
         channels:
           - main
-          - 10.0
           - 9.0
           - 8.0
         additionalJobIdentifier: 'Affinity_85'
@@ -573,7 +555,6 @@ jobs:
           projectFileName: maui_scenarios.proj
           channels:
             - main
-            - 10.0
             - 9.0
             - 8.0
           ${{ each parameter in parameters.jobParameters }}:
@@ -593,7 +574,6 @@ jobs:
         projectFileName: nativeaot_scenarios.proj
         channels:
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -620,7 +600,6 @@ jobs:
         projectFileName: sdk_scenarios.proj
         channels:
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -638,7 +617,6 @@ jobs:
         projectFileName: blazor_scenarios.proj
         channels:
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -661,7 +639,6 @@ jobs:
           runCategories: 'fsharp'
           channels:
             - main
-            - 10.0
             - 9.0
             - 8.0
           ${{ each parameter in parameters.jobParameters }}:
@@ -682,7 +659,6 @@ jobs:
         runCategories: 'FSharpMicro'
         channels:
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -704,7 +680,6 @@ jobs:
         runCategories: 'BepuPhysics'
         channels:
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -726,7 +701,6 @@ jobs:
         runCategories: 'ImageSharp'
         channels:
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:
@@ -748,7 +722,6 @@ jobs:
         runCategories: 'AkadeIndexedSet'
         channels:
           - main
-          - 10.0
           - 9.0
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
@@ -770,7 +743,6 @@ jobs:
         runCategories: 'mldotnet'
         channels:
           - main
-          - 10.0
           - 9.0
           - 8.0
         affinity: '85' # (01010101) Enables alternating process threads to take hyperthreading into account
@@ -798,7 +770,6 @@ jobs:
         runCategories: 'roslyn'
         channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
           - main
-          - 10.0
           - 9.0
           - 8.0
         affinity: '85' # (01010101) Enables alternating process threads to take hyperthreading into account
@@ -826,7 +797,6 @@ jobs:
           runCategories: 'illink'
           channels: # for Roslyn jobs we want to check .NET Core 3.1 and 5.0 only
             - main
-            - 10.0
             - 9.0
             - 8.0
 
@@ -846,7 +816,6 @@ jobs:
         runCategories: 'Public Internal'
         channels:
           - main
-          - 10.0
           - 9.0
           - 8.0
         ${{ each parameter in parameters.jobParameters }}:

--- a/eng/pipelines/sdk-perf-jobs.yml
+++ b/eng/pipelines/sdk-perf-jobs.yml
@@ -24,7 +24,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
-        #- win-x64
+        - win-x64
         - ubuntu-x64
       isPublic: true
       jobParameters:
@@ -44,7 +44,7 @@ jobs:
       parameters:
         jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
         buildMachines:
-          #- win-x64
+          - win-x64
           - ubuntu-x64
         isPublic: true
         jobParameters:
@@ -63,7 +63,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
-        #- win-x64
+        - win-x64
         - ubuntu-x64
       isPublic: true
       jobParameters:
@@ -82,7 +82,6 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
-        #- win-x64
         #- win-x86
         #- ubuntu-x64-1804 reenable under new machine on new ubuntu once lttng/events are available
       isPublic: true
@@ -102,8 +101,8 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        #- win-x64
-        #- win-x86
+        - win-x64
+        - win-x86
       isPublic: true
       jobParameters:
         runKind: micro
@@ -141,7 +140,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        #- win-x64
+        - win-x64
         - ubuntu-x64
       isPublic: true
       jobParameters:
@@ -162,7 +161,7 @@ jobs:
       parameters:
         jobTemplate: /eng/pipelines/templates/run-performance-job.yml
         buildMachines:
-          #- win-x64
+          - win-x64
           - ubuntu-x64
         isPublic: true
         jobParameters:
@@ -181,7 +180,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        #- win-x64
+        - win-x64
         - ubuntu-x64
       isPublic: true
       jobParameters:
@@ -201,7 +200,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        #- win-x64
+        - win-x64
         - ubuntu-x64
       isPublic: true
       jobParameters:
@@ -221,7 +220,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        #- win-x64
+        - win-x64
         - ubuntu-x64
       isPublic: true
       jobParameters:
@@ -241,7 +240,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        #- win-x64
+        - win-x64
         - ubuntu-x64
       isPublic: true
       jobParameters:
@@ -261,7 +260,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        #- win-x64
+        - win-x64
         - ubuntu-x64
       isPublic: true
       jobParameters:
@@ -283,7 +282,7 @@ jobs:
       parameters:
         jobTemplate: /eng/pipelines/templates/run-performance-job.yml
         buildMachines:
-          #- win-x64
+          - win-x64
           - ubuntu-x64
         isPublic: true
         jobParameters:
@@ -303,7 +302,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
-        #- win-x64
+        - win-x64
         - ubuntu-x64
       isPublic: true
       jobParameters:
@@ -322,7 +321,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        #- win-x64
+        - win-x64
         - ubuntu-x64
       isPublic: true
       jobParameters:
@@ -348,8 +347,6 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
-        #- win-x64
-        - ubuntu-x64
         - win-x64-viper
         - ubuntu-x64-viper
         - win-arm64
@@ -371,7 +368,6 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
-        #- win-x64
         - win-x64-viper
         - win-arm64
         - win-arm64-ampere
@@ -567,8 +563,6 @@ jobs:
       parameters:
         jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
         buildMachines:
-          #- win-x64
-          - ubuntu-x64
           - win-x64-viper
           - ubuntu-x64-viper
           - win-arm64
@@ -590,8 +584,6 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
-        #- win-x64
-        - ubuntu-x64
         - win-x64-viper
         - ubuntu-x64-viper
         - win-arm64
@@ -619,9 +611,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
-        #- win-x64
         - win-x64-viper
-        #- win-x86
         - win-x86-viper
         #- ubuntu-x64-1804 reenable under new machine on new ubuntu once lttng/events are available
       isPublic: false
@@ -641,7 +631,6 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
-        #- win-x64
         - win-x64-viper
       isPublic: false
       jobParameters:
@@ -661,8 +650,6 @@ jobs:
       parameters:
         jobTemplate: /eng/pipelines/templates/run-performance-job.yml
         buildMachines:
-          #- win-x64
-          - ubuntu-x64
           - win-x64-viper
           - ubuntu-x64-viper
           - win-arm64
@@ -684,8 +671,6 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        #- win-x64
-        - ubuntu-x64
         - win-x64-viper
         - ubuntu-x64-viper
         - win-arm64
@@ -708,8 +693,6 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        #- win-x64
-        - ubuntu-x64
         - win-x64-viper
         - ubuntu-x64-viper
         - win-arm64
@@ -732,8 +715,6 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        #- win-x64
-        - ubuntu-x64
         - win-x64-viper
         - ubuntu-x64-viper
         - win-arm64
@@ -756,8 +737,6 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        #- win-x64
-        - ubuntu-x64
         - win-x64-viper
         - ubuntu-x64-viper
         - win-arm64
@@ -779,8 +758,6 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        #- win-x64
-        - ubuntu-x64
         - win-x64-viper
         - ubuntu-x64-viper
         - win-arm64
@@ -809,8 +786,6 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        #- win-x64
-        - ubuntu-x64
         - win-x64-viper
         - ubuntu-x64-viper
         - win-arm64
@@ -841,8 +816,6 @@ jobs:
       parameters:
         jobTemplate: /eng/pipelines/templates/run-performance-job.yml
         buildMachines:
-          #- win-x64
-          - ubuntu-x64
           - win-x64-viper
           - ubuntu-x64-viper
           # Illink.Utilities is not supported on ARM: The type initializer for 'ILLinkBenchmarks.Utilities' threw a NotSupportedException (Unsupported architecture). (06/2023)
@@ -862,8 +835,6 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        #- win-x64
-        - ubuntu-x64
         - win-x64-viper
         - ubuntu-x64-viper
         - win-arm64

--- a/eng/pipelines/sdk-perf-jobs.yml
+++ b/eng/pipelines/sdk-perf-jobs.yml
@@ -507,6 +507,24 @@ jobs:
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
+  # Maui iOS CoreCLR scenario benchmarks
+  - template: /eng/pipelines/templates/build-machine-matrix.yml
+    parameters:
+      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
+      buildMachines:
+        - osx-x64-ios-arm64
+      isPublic: false
+      jobParameters:
+        runKind: maui_scenarios_ios
+        projectFileName: maui_scenarios_ios.proj
+        channels:
+          - main
+        runtimeFlavor: coreclr
+        codeGenType: Interpreter
+        additionalJobIdentifier: CoreCLR
+        ${{ each parameter in parameters.jobParameters }}:
+          ${{ parameter.key }}: ${{ parameter.value }}
+
   # Maui iOS Native AOT scenario benchmarks
   - template: /eng/pipelines/templates/build-machine-matrix.yml
     parameters:

--- a/eng/pipelines/sdk-perf-jobs.yml
+++ b/eng/pipelines/sdk-perf-jobs.yml
@@ -370,7 +370,7 @@ jobs:
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
-  # Maui Android scenario benchmarks (Mono ProfiledAOT) - Release
+  # Maui Android scenario benchmarks (Mono Default) - Release
   - template: /eng/pipelines/templates/build-machine-matrix.yml
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
@@ -384,13 +384,13 @@ jobs:
         channels:
           - main
         runtimeFlavor: mono
-        codeGenType: ProfiledAOT
+        codeGenType: Default
         buildConfig: Release
         additionalJobIdentifier: Mono
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
-  # Maui Android scenario benchmarks (CoreCLR JIT) - Release
+  # Maui Android scenario benchmarks (CoreCLR Default) - Release
   - template: /eng/pipelines/templates/build-machine-matrix.yml
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
@@ -404,47 +404,7 @@ jobs:
         channels:
           - main
         runtimeFlavor: coreclr
-        codeGenType: JIT
-        buildConfig: Release
-        additionalJobIdentifier: CoreCLR
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
-
-  # Maui Android scenario benchmarks (CoreCLR R2R) - Release
-  - template: /eng/pipelines/templates/build-machine-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-      buildMachines:
-        - win-x64-android-arm64-pixel
-        - win-x64-android-arm64-galaxy
-      isPublic: false
-      jobParameters:
-        runKind: maui_scenarios_android
-        projectFileName: maui_scenarios_android.proj
-        channels:
-          - main
-        runtimeFlavor: coreclr
-        codeGenType: R2R
-        buildConfig: Release
-        additionalJobIdentifier: CoreCLR
-        ${{ each parameter in parameters.jobParameters }}:
-          ${{ parameter.key }}: ${{ parameter.value }}
-
-  # Maui Android scenario benchmarks (CoreCLR R2R Composite) - Release
-  - template: /eng/pipelines/templates/build-machine-matrix.yml
-    parameters:
-      jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
-      buildMachines:
-        - win-x64-android-arm64-pixel
-        - win-x64-android-arm64-galaxy
-      isPublic: false
-      jobParameters:
-        runKind: maui_scenarios_android
-        projectFileName: maui_scenarios_android.proj
-        channels:
-          - main
-        runtimeFlavor: coreclr
-        codeGenType: R2RComposite
+        codeGenType: Default
         buildConfig: Release
         additionalJobIdentifier: CoreCLR
         ${{ each parameter in parameters.jobParameters }}:
@@ -470,7 +430,7 @@ jobs:
         ${{ each parameter in parameters.jobParameters }}:
           ${{ parameter.key }}: ${{ parameter.value }}
 
-  # Maui iOS scenario benchmarks (Mono FullAOT) - Release
+  # Maui iOS scenario benchmarks (Mono Default) - Release
   - template: /eng/pipelines/templates/build-machine-matrix.yml
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
@@ -483,7 +443,7 @@ jobs:
         channels:
           - main
         runtimeFlavor: mono
-        codeGenType: FullAOT
+        codeGenType: Default
         buildConfig: Release
         additionalJobIdentifier: Mono
         ${{ each parameter in parameters.jobParameters }}:

--- a/eng/pipelines/sdk-perf-jobs.yml
+++ b/eng/pipelines/sdk-perf-jobs.yml
@@ -24,7 +24,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
-        - win-x64
+        #- win-x64
         - ubuntu-x64
       isPublic: true
       jobParameters:
@@ -43,7 +43,7 @@ jobs:
       parameters:
         jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
         buildMachines:
-          - win-x64
+          #- win-x64
           - ubuntu-x64
         isPublic: true
         jobParameters:
@@ -61,7 +61,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
-        - win-x64
+        #- win-x64
         - ubuntu-x64
       isPublic: true
       jobParameters:
@@ -79,8 +79,8 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
-        - win-x64
-        - win-x86
+        #- win-x64
+        #- win-x86
         #- ubuntu-x64-1804 reenable under new machine on new ubuntu once lttng/events are available
       isPublic: true
       jobParameters:
@@ -98,8 +98,8 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        - win-x64
-        - win-x86
+        #- win-x64
+        #- win-x86
       isPublic: true
       jobParameters:
         runKind: micro
@@ -135,7 +135,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        - win-x64
+        #- win-x64
         - ubuntu-x64
       isPublic: true
       jobParameters:
@@ -155,7 +155,7 @@ jobs:
       parameters:
         jobTemplate: /eng/pipelines/templates/run-performance-job.yml
         buildMachines:
-          - win-x64
+          #- win-x64
           - ubuntu-x64
         isPublic: true
         jobParameters:
@@ -173,7 +173,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        - win-x64
+        #- win-x64
         - ubuntu-x64
       isPublic: true
       jobParameters:
@@ -192,7 +192,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        - win-x64
+        #- win-x64
         - ubuntu-x64
       isPublic: true
       jobParameters:
@@ -211,7 +211,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        - win-x64
+        #- win-x64
         - ubuntu-x64
       isPublic: true
       jobParameters:
@@ -230,7 +230,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        - win-x64
+        #- win-x64
         - ubuntu-x64
       isPublic: true
       jobParameters:
@@ -249,7 +249,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        - win-x64
+        #- win-x64
         - ubuntu-x64
       isPublic: true
       jobParameters:
@@ -270,7 +270,7 @@ jobs:
       parameters:
         jobTemplate: /eng/pipelines/templates/run-performance-job.yml
         buildMachines:
-          - win-x64
+          #- win-x64
           - ubuntu-x64
         isPublic: true
         jobParameters:
@@ -289,7 +289,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
-        - win-x64
+        #- win-x64
         - ubuntu-x64
       isPublic: true
       jobParameters:
@@ -307,7 +307,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        - win-x64
+        #- win-x64
         - ubuntu-x64
       isPublic: true
       jobParameters:
@@ -332,7 +332,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
-        - win-x64
+        #- win-x64
         - ubuntu-x64
         - win-x64-viper
         - ubuntu-x64-viper
@@ -354,7 +354,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
-        - win-x64
+        #- win-x64
         - win-x64-viper
         - win-arm64
         - win-arm64-ampere
@@ -531,7 +531,7 @@ jobs:
       parameters:
         jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
         buildMachines:
-          - win-x64
+          #- win-x64
           - ubuntu-x64
           - win-x64-viper
           - ubuntu-x64-viper
@@ -553,7 +553,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
-        - win-x64
+        #- win-x64
         - ubuntu-x64
         - win-x64-viper
         - ubuntu-x64-viper
@@ -581,9 +581,9 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
-        - win-x64
+        #- win-x64
         - win-x64-viper
-        - win-x86
+        #- win-x86
         - win-x86-viper
         #- ubuntu-x64-1804 reenable under new machine on new ubuntu once lttng/events are available
       isPublic: false
@@ -602,7 +602,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-scenarios-job.yml
       buildMachines:
-        - win-x64
+        #- win-x64
         - win-x64-viper
       isPublic: false
       jobParameters:
@@ -621,7 +621,7 @@ jobs:
       parameters:
         jobTemplate: /eng/pipelines/templates/run-performance-job.yml
         buildMachines:
-          - win-x64
+          #- win-x64
           - ubuntu-x64
           - win-x64-viper
           - ubuntu-x64-viper
@@ -643,7 +643,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        - win-x64
+        #- win-x64
         - ubuntu-x64
         - win-x64-viper
         - ubuntu-x64-viper
@@ -666,7 +666,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        - win-x64
+        #- win-x64
         - ubuntu-x64
         - win-x64-viper
         - ubuntu-x64-viper
@@ -689,7 +689,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        - win-x64
+        #- win-x64
         - ubuntu-x64
         - win-x64-viper
         - ubuntu-x64-viper
@@ -712,7 +712,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        - win-x64
+        #- win-x64
         - ubuntu-x64
         - win-x64-viper
         - ubuntu-x64-viper
@@ -734,7 +734,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        - win-x64
+        #- win-x64
         - ubuntu-x64
         - win-x64-viper
         - ubuntu-x64-viper
@@ -763,7 +763,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        - win-x64
+        #- win-x64
         - ubuntu-x64
         - win-x64-viper
         - ubuntu-x64-viper
@@ -794,7 +794,7 @@ jobs:
       parameters:
         jobTemplate: /eng/pipelines/templates/run-performance-job.yml
         buildMachines:
-          - win-x64
+          #- win-x64
           - ubuntu-x64
           - win-x64-viper
           - ubuntu-x64-viper
@@ -814,7 +814,7 @@ jobs:
     parameters:
       jobTemplate: /eng/pipelines/templates/run-performance-job.yml
       buildMachines:
-        - win-x64
+        #- win-x64
         - ubuntu-x64
         - win-x64-viper
         - ubuntu-x64-viper

--- a/eng/pipelines/templates/build-machine-matrix.yml
+++ b/eng/pipelines/templates/build-machine-matrix.yml
@@ -10,8 +10,13 @@ jobs:
     parameters:
       osGroup: windows
       archType: x64
-      pool:
-        vmImage: windows-2025
+      ${{ if eq(parameters.isPublic, true) }}:
+        pool:
+          name: NetCore-Public
+          demands: ImageOverride -equals windows.vs2022.amd64.open
+      ${{ else }}:
+        pool:
+          vmImage: windows-2025
       ${{ insert }}: ${{ parameters.jobParameters }}
       ${{ if eq(parameters.isPublic, true) }}:
         osVersion: 24H2
@@ -29,7 +34,8 @@ jobs:
       osVersion: RS5
       archType: x64
       pool:
-        vmImage: windows-2025
+        name: NetCore-Public
+        demands: ImageOverride -equals windows.vs2022.amd64.open
       machinePool: Open
       queue: Windows.10.Amd64.ClientRS5.Open
       ${{ insert }}: ${{ parameters.jobParameters }}
@@ -39,8 +45,13 @@ jobs:
     parameters:
       osGroup: windows
       archType: x86
-      pool:
-        vmImage: windows-2025
+      ${{ if eq(parameters.isPublic, true) }}:
+        pool:
+          name: NetCore-Public
+          demands: ImageOverride -equals windows.vs2022.amd64.open
+      ${{ else }}:
+        pool:
+          vmImage: windows-2025
       ${{ insert }}: ${{ parameters.jobParameters }}
       ${{ if eq(parameters.isPublic, true) }}:
         osVersion: 24H2
@@ -57,8 +68,13 @@ jobs:
       osGroup: ubuntu
       osVersion: 2204
       archType: x64
-      pool: 
-        vmImage: ubuntu-latest
+      ${{ if eq(parameters.isPublic, true) }}:
+        pool:
+          name: NetCore-Public
+          demands: ImageOverride -equals build.azurelinux.3.amd64.open
+      ${{ else }}:
+        pool: 
+          vmImage: ubuntu-latest
       container: ubuntu_x64_build_container
       ${{ insert }}: ${{ parameters.jobParameters }}
       ${{ if eq(parameters.isPublic, true) }}:

--- a/eng/pipelines/templates/build-machine-matrix.yml
+++ b/eng/pipelines/templates/build-machine-matrix.yml
@@ -93,6 +93,19 @@ jobs:
       queue: Ubuntu.2204.Arm64.Perf
       ${{ insert }}: ${{ parameters.jobParameters }}
 
+- ${{ if and(containsValue(parameters.buildMachines, 'azurelinux3-arm64-cobalt'), not(eq(parameters.isPublic, true))) }}: # Azure Linux 3 ARM64 Cobalt only used in private builds currently
+  - template: ${{ parameters.jobTemplate }}
+    parameters:
+      osGroup: azurelinux
+      osVersion: 3
+      archType: arm64
+      pool:
+        vmImage: ubuntu-latest
+      container: ubuntu_x64_build_container
+      machinePool: Cobalt
+      queue: AzureLinux.3.Cobalt.Arm64.Perf
+      ${{ insert }}: ${{ parameters.jobParameters }}
+
 - ${{ if and(containsValue(parameters.buildMachines, 'win-x64-android-arm64-pixel'), not(eq(parameters.isPublic, true))) }}: # Windows ARM64 Pixel only used in private builds currently
   - template: ${{ parameters.jobTemplate }}
     parameters:

--- a/eng/pipelines/templates/run-performance-job.yml
+++ b/eng/pipelines/templates/run-performance-job.yml
@@ -28,6 +28,7 @@ parameters:
   archType: ''                      # required -- Architecture of Helix machine
   osGroup: ''                       # required -- OS of Helix machine
   osSubGroup: ''                    # optional -- OS Subgroup of Helix machine
+  osDistro: ''                      # optional -- OS distribution (e.g. 'azurelinux', 'ubuntu'). Used to determine package manager.
   queue: ''                         # optional -- Helix queue to run on (required if logicalMachine is not set)
   logicalMachine: ''                # optional -- Type of Helix machine to use (required if queue is not set)
   channel: ''                       # optional -- .NET channel to test against (use channels). Ignored if channels or dotnetVersionLinks is non-empty
@@ -161,6 +162,8 @@ jobs:
             - '--os-group ${{ parameters.osGroup }}'
             - ${{ if ne(parameters.osSubGroup, '') }}:
               - '--os-sub-group ${{ parameters.osSubGroup }}'
+            - ${{ if ne(parameters.osDistro, '') }}:
+              - '--os-distro ${{ parameters.osDistro }}'
             - ${{ if ne(parameters.queue, '') }}:
               - '--queue ${{ parameters.queue }}'
             - ${{ if ne(parameters.logicalMachine, '') }}:
@@ -251,11 +254,11 @@ jobs:
               -TokensFilePath '$(System.DefaultWorkingDirectory)/eng/BinlogSecretsRedactionFile.txt'
           continueOnError: true
           condition: always()
-      - ${{ if eq(parameters.osGroup, 'ubuntu') }}:
+      - ${{ if eq(parameters.osGroup, 'linux') }}:
         - task: ShellScript@2
           displayName: Redact Logs
           inputs:
-            scriptPath: $(System.DefaultWorkingDirectory)/eng/performance/redact-logs.sh
-            args: '--input $(System.DefaultWorkingDirectory)/artifacts/log --version 1.0.11 --tokens-file $(System.DefaultWorkingDirectory)/eng/BinlogSecretsRedactionFile.txt'
+            scriptPath: $(System.DefaultWorkingDirectory)/performance/eng/performance/redact-logs.sh
+            args: '--input $(System.DefaultWorkingDirectory)/artifacts/log --version 1.0.11 --tokens-file $(System.DefaultWorkingDirectory)/performance/eng/BinlogSecretsRedactionFile.txt'
           continueOnError: true
           condition: always()

--- a/eng/pipelines/templates/run-performance-job.yml
+++ b/eng/pipelines/templates/run-performance-job.yml
@@ -53,7 +53,7 @@ parameters:
   experimentName: ''                # optional -- Name of the experiment
   javascriptEngine: ''              # optional -- JavaScript engine to use
   iOSLlvmBuild: false               # optional -- Whether to build iOS with LLVM
-  iOSStripSymbols: false            # optional -- Whether to strip symbols from the iOS build
+  iOSStripSymbols: true            # optional -- Whether to strip symbols from the iOS build
   additionalSetupParameters: ''     # optional -- Additional arguments to pass to the script
   liveLibrariesBuildConfig: ''      # optional -- Build configuration when generating Core_Root for libraries
   crossBuild: false                 # optional -- Whether the Core_Root is being cross-compiled

--- a/eng/pipelines/templates/runtime-perf-job.yml
+++ b/eng/pipelines/templates/runtime-perf-job.yml
@@ -52,7 +52,7 @@ jobs:
         - ${{ if eq(parameters.runtimeType, 'iOSMono')}}:
           - ${{ 'build_ios_arm64_release_iOSMono' }}
         - ${{ if eq(parameters.runtimeType, 'iOSCoreCLR')}}:
-          - ${{ 'build_ios_arm64_checked_iOSCoreCLR' }}
+          - ${{ 'build_ios_arm64_release_iOSCoreCLR' }}
         - ${{ if eq(parameters.runtimeType, 'iOSNativeAOT')}}:
           - ${{ 'build_ios_arm64_release_iOSNativeAOT' }}
 

--- a/eng/pipelines/templates/runtime-perf-job.yml
+++ b/eng/pipelines/templates/runtime-perf-job.yml
@@ -1,7 +1,7 @@
 parameters:
   steps: []
   variables: []
-  framework: net10.0 # Specify the appropriate framework when running release branches (ie net6.0 for release/6.0)
+  framework: net11.0 # Specify the appropriate framework when running release branches (ie net6.0 for release/6.0)
   buildConfig: ''
   archType: ''
   osGroup: ''

--- a/eng/pipelines/templates/runtime-perf-job.yml
+++ b/eng/pipelines/templates/runtime-perf-job.yml
@@ -195,6 +195,9 @@ jobs:
             ${{ if and(eq(parameters.runtimeType, 'iOSCoreCLR'), eq(parameters.codeGenType, 'Interpreter'), eq(parameters.iOSStripSymbols, 'True')) }}:
               artifactName: 'iOSSampleAppCoreCLRInterpreterNoSymbols'
               artifactFileName: 'iOSSampleAppCoreCLRInterpreterNoSymbols.zip'
+            ${{ if and(eq(parameters.runtimeType, 'iOSCoreCLR'), eq(parameters.codeGenType, 'R2R'), eq(parameters.iOSStripSymbols, 'True')) }}:
+              artifactName: 'iOSSampleAppCoreCLRR2RNoSymbols'
+              artifactFileName: 'iOSSampleAppCoreCLRR2RNoSymbols.zip'
             ${{ if and(eq(parameters.runtimeType, 'iOSNativeAOT'), eq(parameters.iOSStripSymbols, 'True')) }}:
               artifactName: 'iOSSampleAppNativeAOTNoSymbols'
               artifactFileName: 'iOSSampleAppNativeAOTNoSymbols.zip'
@@ -212,6 +215,8 @@ jobs:
               artifactName: 'iOSSampleAppMonoFullAOTLLVMNoSymbols'
             ${{ if and(eq(parameters.runtimeType, 'iOSCoreCLR'), eq(parameters.codeGenType, 'Interpreter'), eq(parameters.iOSStripSymbols, 'True')) }}:
               artifactName: 'iOSSampleAppCoreCLRInterpreterNoSymbols'
+            ${{ if and(eq(parameters.runtimeType, 'iOSCoreCLR'), eq(parameters.codeGenType, 'R2R'), eq(parameters.iOSStripSymbols, 'True')) }}:
+              artifactName: 'iOSSampleAppCoreCLRR2RNoSymbols'
             ${{ if and(eq(parameters.runtimeType, 'iOSNativeAOT'), eq(parameters.iOSStripSymbols, 'True')) }}:
               artifactName: 'iOSSampleAppNativeAOTNoSymbols'
             checkDownloadedFiles: true
@@ -227,6 +232,8 @@ jobs:
               artifactName: 'iOSMonoFullAOTArm64LLVMStripSymbolsBuildLog'
             ${{ if and(eq(parameters.runtimeType, 'iOSCoreCLR'), eq(parameters.codeGenType, 'Interpreter'), eq(parameters.iOSStripSymbols, 'True')) }}:
               artifactName: 'iOSCoreCLRInterpreterArm64StripSymbolsBuildLog'
+            ${{ if and(eq(parameters.runtimeType, 'iOSCoreCLR'), eq(parameters.codeGenType, 'R2R'), eq(parameters.iOSStripSymbols, 'True')) }}:
+              artifactName: 'iOSCoreCLRR2RArm64StripSymbolsBuildLog'
             ${{ if and(eq(parameters.runtimeType, 'iOSNativeAOT'), eq(parameters.iOSStripSymbols, 'True')) }}:
               artifactName: 'iOSNativeAOTArm64StripSymbolsBuildLog'
             checkDownloadedFiles: true

--- a/eng/pipelines/templates/runtime-perf-job.yml
+++ b/eng/pipelines/templates/runtime-perf-job.yml
@@ -12,7 +12,7 @@ parameters:
   codeGenType: 'JIT'
   linkingType: '' # dynamic is default
   iOSLlvmBuild: 'False'
-  iOSStripSymbols: 'False'
+  iOSStripSymbols: 'True'
   isScenario: false
   downloadSpecificBuild: null # buildId, pipeline, branchName, project
   crossBuild: false
@@ -181,31 +181,23 @@ jobs:
         #     displayName: 'Mono Android BDN Apk'
       - ${{ elseif or(eq(parameters.runtimeType, 'iOSMono'), eq(parameters.runtimeType, 'iOSCoreCLR'), eq(parameters.runtimeType, 'iOSNativeAOT')) }}:
         # Download iOS Mono and CoreCLR (NativeAOT) tests
+        # Currently only running scenarios where iOSStripSymbols == 'True'
         - template: /eng/pipelines/templates/download-artifact-step.yml
           parameters:
             unpackFolder: $(builtAppDir)/iosHelloWorld
             cleanUnpackFolder: false
-            ${{ if and(eq(parameters.runtimeType, 'iOSMono'), eq(parameters.iOSLlvmBuild, 'False'), eq(parameters.iOSStripSymbols, 'False')) }}:
-              artifactName: 'iOSSampleAppNoLLVMSymbols'
-              artifactFileName: 'iOSSampleAppNoLLVMSymbols.zip'
-            ${{ if and(eq(parameters.runtimeType, 'iOSMono'), eq(parameters.iOSLlvmBuild, 'False'), eq(parameters.iOSStripSymbols, 'True')) }}:
-              artifactName: 'iOSSampleAppNoLLVMNoSymbols'
-              artifactFileName: 'iOSSampleAppNoLLVMNoSymbols.zip'
-            ${{ if and(eq(parameters.runtimeType, 'iOSMono'), eq(parameters.iOSLlvmBuild, 'True'), eq(parameters.iOSStripSymbols, 'False')) }}:
-              artifactName: 'iOSSampleAppLLVMSymbols'
-              artifactFileName: 'iOSSampleAppLLVMSymbols.zip'
-            ${{ if and(eq(parameters.runtimeType, 'iOSMono'), eq(parameters.iOSLlvmBuild, 'True'), eq(parameters.iOSStripSymbols, 'True')) }}:
-              artifactName: 'iOSSampleAppLLVMNoSymbols'
-              artifactFileName: 'iOSSampleAppLLVMNoSymbols.zip'
-            ${{ if and(eq(parameters.runtimeType, 'iOSCoreCLR'), eq(parameters.codeGenType, 'Interpreter')) }}:
-              artifactName: 'iOSSampleApp'
-              artifactFileName: 'iOSSampleApp.zip'
-            ${{ if and(eq(parameters.runtimeType, 'iOSNativeAOT'), eq(parameters.iOSStripSymbols, 'False')) }}:
-              artifactName: 'iOSSampleAppSymbols'
-              artifactFileName: 'iOSSampleAppSymbols.zip'
+            ${{ if and(eq(parameters.runtimeType, 'iOSMono'), eq(parameters.codeGenType, 'FullAOT'), eq(parameters.iOSLlvmBuild, 'False'), eq(parameters.iOSStripSymbols, 'True')) }}:
+              artifactName: 'iOSSampleAppMonoFullAOTNoLLVMNoSymbols'
+              artifactFileName: 'iOSSampleAppMonoFullAOTNoLLVMNoSymbols.zip'
+            ${{ if and(eq(parameters.runtimeType, 'iOSMono'), eq(parameters.codeGenType, 'FullAOT'), eq(parameters.iOSLlvmBuild, 'True'), eq(parameters.iOSStripSymbols, 'True')) }}:
+              artifactName: 'iOSSampleAppMonoFullAOTLLVMNoSymbols'
+              artifactFileName: 'iOSSampleAppMonoFullAOTLLVMNoSymbols.zip'
+            ${{ if and(eq(parameters.runtimeType, 'iOSCoreCLR'), eq(parameters.codeGenType, 'Interpreter'), eq(parameters.iOSStripSymbols, 'True')) }}:
+              artifactName: 'iOSSampleAppCoreCLRInterpreterNoSymbols'
+              artifactFileName: 'iOSSampleAppCoreCLRInterpreterNoSymbols.zip'
             ${{ if and(eq(parameters.runtimeType, 'iOSNativeAOT'), eq(parameters.iOSStripSymbols, 'True')) }}:
-              artifactName: 'iOSSampleAppNoSymbols'
-              artifactFileName: 'iOSSampleAppNoSymbols.zip'
+              artifactName: 'iOSSampleAppNativeAOTNoSymbols'
+              artifactFileName: 'iOSSampleAppNativeAOTNoSymbols.zip'
             displayName: 'iOS Sample App'
         # same artifact as above but don't extract .zip
         - task: DownloadBuildArtifacts@0
@@ -214,20 +206,14 @@ jobs:
             buildType: current
             downloadType: single
             downloadPath: '$(builtAppDir)/iosHelloWorldZip'
-            ${{ if and(eq(parameters.runtimeType, 'iOSMono'), eq(parameters.iOSLlvmBuild, 'False'), eq(parameters.iOSStripSymbols, 'False')) }}:
-              artifactName: 'iOSSampleAppNoLLVMSymbols'
-            ${{ if and(eq(parameters.runtimeType, 'iOSMono'), eq(parameters.iOSLlvmBuild, 'False'), eq(parameters.iOSStripSymbols, 'True')) }}:
-              artifactName: 'iOSSampleAppNoLLVMNoSymbols'
-            ${{ if and(eq(parameters.runtimeType, 'iOSMono'), eq(parameters.iOSLlvmBuild, 'True'), eq(parameters.iOSStripSymbols, 'False')) }}:
-              artifactName: 'iOSSampleAppLLVMSymbols'
-            ${{ if and(eq(parameters.runtimeType, 'iOSMono'), eq(parameters.iOSLlvmBuild, 'True'), eq(parameters.iOSStripSymbols, 'True')) }}:
-              artifactName: 'iOSSampleAppLLVMNoSymbols'
-            ${{ if and(eq(parameters.runtimeType, 'iOSCoreCLR'), eq(parameters.codeGenType, 'Interpreter')) }}:
-              artifactName: 'iOSSampleApp'
-            ${{ if and(eq(parameters.runtimeType, 'iOSNativeAOT'), eq(parameters.iOSStripSymbols, 'False')) }}:
-              artifactName: 'iOSSampleAppSymbols'
+            ${{ if and(eq(parameters.runtimeType, 'iOSMono'), eq(parameters.codeGenType, 'FullAOT'), eq(parameters.iOSLlvmBuild, 'False'), eq(parameters.iOSStripSymbols, 'True')) }}:
+              artifactName: 'iOSSampleAppMonoFullAOTNoLLVMNoSymbols'
+            ${{ if and(eq(parameters.runtimeType, 'iOSMono'), eq(parameters.codeGenType, 'FullAOT'), eq(parameters.iOSLlvmBuild, 'True'), eq(parameters.iOSStripSymbols, 'True')) }}:
+              artifactName: 'iOSSampleAppMonoFullAOTLLVMNoSymbols'
+            ${{ if and(eq(parameters.runtimeType, 'iOSCoreCLR'), eq(parameters.codeGenType, 'Interpreter'), eq(parameters.iOSStripSymbols, 'True')) }}:
+              artifactName: 'iOSSampleAppCoreCLRInterpreterNoSymbols'
             ${{ if and(eq(parameters.runtimeType, 'iOSNativeAOT'), eq(parameters.iOSStripSymbols, 'True')) }}:
-              artifactName: 'iOSSampleAppNoSymbols'
+              artifactName: 'iOSSampleAppNativeAOTNoSymbols'
             checkDownloadedFiles: true
         - task: DownloadBuildArtifacts@0
           displayName: 'Download binlog files'
@@ -235,18 +221,12 @@ jobs:
             buildType: current
             downloadType: single
             downloadPath: '$(builtAppDir)/iosHelloWorldBinlog'
-            ${{ if and(eq(parameters.runtimeType, 'iOSMono'), eq(parameters.iOSLlvmBuild, 'False'), eq(parameters.iOSStripSymbols, 'False')) }}:
-              artifactName: 'iOSMonoArm64NoLLVMNoStripSymbolsBuildLog'
-            ${{ if and(eq(parameters.runtimeType, 'iOSMono'), eq(parameters.iOSLlvmBuild, 'False'), eq(parameters.iOSStripSymbols, 'True')) }}:
-              artifactName: 'iOSMonoArm64NoLLVMStripSymbolsBuildLog'
-            ${{ if and(eq(parameters.runtimeType, 'iOSMono'), eq(parameters.iOSLlvmBuild, 'True'), eq(parameters.iOSStripSymbols, 'False')) }}:
-              artifactName: 'iOSMonoArm64LLVMNoStripSymbolsBuildLog'
-            ${{ if and(eq(parameters.runtimeType, 'iOSMono'), eq(parameters.iOSLlvmBuild, 'True'), eq(parameters.iOSStripSymbols, 'True')) }}:
-              artifactName: 'iOSMonoArm64LLVMStripSymbolsBuildLog'
-            ${{ if and(eq(parameters.runtimeType, 'iOSCoreCLR'), eq(parameters.codeGenType, 'Interpreter')) }}:
-              artifactName: 'iOSCoreCLRArm64BuildLog'
-            ${{ if and(eq(parameters.runtimeType, 'iOSNativeAOT'), eq(parameters.iOSStripSymbols, 'False')) }}:
-              artifactName: 'iOSNativeAOTArm64NoStripSymbolsBuildLog'
+            ${{ if and(eq(parameters.runtimeType, 'iOSMono'), eq(parameters.codeGenType, 'FullAOT'), eq(parameters.iOSLlvmBuild, 'False'), eq(parameters.iOSStripSymbols, 'True')) }}:
+              artifactName: 'iOSMonoFullAOTArm64NoLLVMStripSymbolsBuildLog'
+            ${{ if and(eq(parameters.runtimeType, 'iOSMono'), eq(parameters.codeGenType, 'FullAOT'), eq(parameters.iOSLlvmBuild, 'True'), eq(parameters.iOSStripSymbols, 'True')) }}:
+              artifactName: 'iOSMonoFullAOTArm64LLVMStripSymbolsBuildLog'
+            ${{ if and(eq(parameters.runtimeType, 'iOSCoreCLR'), eq(parameters.codeGenType, 'Interpreter'), eq(parameters.iOSStripSymbols, 'True')) }}:
+              artifactName: 'iOSCoreCLRInterpreterArm64StripSymbolsBuildLog'
             ${{ if and(eq(parameters.runtimeType, 'iOSNativeAOT'), eq(parameters.iOSStripSymbols, 'True')) }}:
               artifactName: 'iOSNativeAOTArm64StripSymbolsBuildLog'
             checkDownloadedFiles: true

--- a/eng/pipelines/upload-build-artifacts-jobs.yml
+++ b/eng/pipelines/upload-build-artifacts-jobs.yml
@@ -146,7 +146,7 @@ jobs:
     - template: /eng/pipelines/templates/upload-build-artifacts-job.yml@${{ parameters.performanceRepoAlias }}
       parameters:
         buildType: 'coreclr_arm64_ios'
-        dependencyJobName: build_ios_arm64_checked_iOSCoreCLR
+        dependencyJobName: build_ios_arm64_release_iOSCoreCLR
         artifacts:
         - artifactName: 'iOSSampleAppCoreCLRInterpreterNoSymbols'
           files: [ 'iOSSampleAppCoreCLRInterpreterNoSymbols.zip' ]

--- a/eng/pipelines/upload-build-artifacts-jobs.yml
+++ b/eng/pipelines/upload-build-artifacts-jobs.yml
@@ -139,8 +139,6 @@ jobs:
         buildType: 'nativeAot_arm64_ios'
         dependencyJobName: build_ios_arm64_release_iOSNativeAOT
         artifacts:
-        - artifactName: 'iOSSampleAppSymbols'
-          files: [ 'iOSSampleAppSymbols.zip' ]
         - artifactName: 'iOSSampleAppNativeAOTNoSymbols'
           files: [ 'iOSSampleAppNativeAOTNoSymbols.zip' ]
 

--- a/eng/pipelines/upload-build-artifacts-jobs.yml
+++ b/eng/pipelines/upload-build-artifacts-jobs.yml
@@ -119,14 +119,10 @@ jobs:
         buildType: 'mono_arm64_ios'
         dependencyJobName: build_ios_arm64_release_iOSMono
         artifacts:
-        - artifactName: 'iOSSampleAppLLVMNoSymbols'
-          files: [ 'iOSSampleAppLLVMNoSymbols.zip' ]
-        - artifactName: 'iOSSampleAppLLVMSymbols'
-          files: [ 'iOSSampleAppLLVMSymbols.zip' ]
-        - artifactName: 'iOSSampleAppNoLLVMNoSymbols'
-          files: [ 'iOSSampleAppNoLLVMNoSymbols.zip' ]
-        - artifactName: 'iOSSampleAppNoLLVMSymbols'
-          files: [ 'iOSSampleAppNoLLVMSymbols.zip' ]
+        - artifactName: 'iOSSampleAppMonoFullAOTLLVMNoSymbols'
+          files: [ 'iOSSampleAppMonoFullAOTLLVMNoSymbols.zip' ]
+        - artifactName: 'iOSSampleAppMonoFullAOTNoLLVMNoSymbols'
+          files: [ 'iOSSampleAppMonoFullAOTNoLLVMNoSymbols.zip' ]
                     
   - ${{ if containsValue(parameters.buildType, 'monoBDN_arm64_android') }}:
     - template: /eng/pipelines/templates/upload-build-artifacts-job.yml@${{ parameters.performanceRepoAlias }}
@@ -145,8 +141,8 @@ jobs:
         artifacts:
         - artifactName: 'iOSSampleAppSymbols'
           files: [ 'iOSSampleAppSymbols.zip' ]
-        - artifactName: 'iOSSampleAppNoSymbols'
-          files: [ 'iOSSampleAppNoSymbols.zip' ]
+        - artifactName: 'iOSSampleAppNativeAOTNoSymbols'
+          files: [ 'iOSSampleAppNativeAOTNoSymbols.zip' ]
 
   - ${{ if containsValue(parameters.buildType, 'coreclr_arm64_ios') }}:
     - template: /eng/pipelines/templates/upload-build-artifacts-job.yml@${{ parameters.performanceRepoAlias }}
@@ -154,5 +150,5 @@ jobs:
         buildType: 'coreclr_arm64_ios'
         dependencyJobName: build_ios_arm64_checked_iOSCoreCLR
         artifacts:
-        - artifactName: 'iOSSampleApp'
-          files: [ 'iOSSampleApp.zip' ]
+        - artifactName: 'iOSSampleAppCoreCLRInterpreterNoSymbols'
+          files: [ 'iOSSampleAppCoreCLRInterpreterNoSymbols.zip' ]

--- a/eng/pipelines/upload-build-artifacts-jobs.yml
+++ b/eng/pipelines/upload-build-artifacts-jobs.yml
@@ -150,3 +150,5 @@ jobs:
         artifacts:
         - artifactName: 'iOSSampleAppCoreCLRInterpreterNoSymbols'
           files: [ 'iOSSampleAppCoreCLRInterpreterNoSymbols.zip' ]
+        - artifactName: 'iOSSampleAppCoreCLRR2RNoSymbols'
+          files: [ 'iOSSampleAppCoreCLRR2RNoSymbols.zip' ]

--- a/es-metadata.yml
+++ b/es-metadata.yml
@@ -1,0 +1,8 @@
+schemaVersion: 0.0.1
+isProduction: false
+accountableOwners:
+  service: dc9f7233-4f4a-491d-b775-8a01bced321c
+routing:
+  defaultAreaPath:
+    org: devdiv
+    path: DevDiv\NET Fundamentals\Performance

--- a/global.json
+++ b/global.json
@@ -1,15 +1,15 @@
 {
   "sdk": {
-    "version": "10.0.100-rc.1.25420.111",
+    "version": "10.0.100-rc.2.25502.107",
     "allowPrerelease": true,
     "rollForward": "major"
   },
   "tools": {
-    "dotnet": "10.0.100-rc.1.25420.111"
+    "dotnet": "10.0.100-rc.2.25502.107"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.25514.106",
-    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.25514.106"
+    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.25555.107",
+    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.25555.107"
   },
   "native-tools": {
     "python3": "3.7.1"

--- a/global.json
+++ b/global.json
@@ -8,8 +8,8 @@
     "dotnet": "10.0.100-rc.1.25420.111"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.25508.109",
-    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.25508.109"
+    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.25514.106",
+    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.25514.106"
   },
   "native-tools": {
     "python3": "3.7.1"

--- a/global.json
+++ b/global.json
@@ -8,8 +8,8 @@
     "dotnet": "10.0.100-rc.1.25420.111"
   },
   "msbuild-sdks": {
-    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.25479.101",
-    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.25479.101"
+    "Microsoft.DotNet.Arcade.Sdk": "11.0.0-beta.25508.109",
+    "Microsoft.DotNet.Helix.Sdk": "11.0.0-beta.25508.109"
   },
   "native-tools": {
     "python3": "3.7.1"

--- a/global.net10.json
+++ b/global.net10.json
@@ -1,0 +1,17 @@
+{
+  "sdk": {
+    "version": "10.0.100",
+    "allowPrerelease": true,
+    "rollForward": "latestMinor"
+  },
+  "tools": {
+    "dotnet": "10.0.100"
+  },
+  "msbuild-sdks": {
+    "Microsoft.DotNet.Arcade.Sdk": "10.0.0-beta.25604.105",
+    "Microsoft.DotNet.Helix.Sdk": "10.0.0-beta.25604.105"
+  },
+  "native-tools": {
+    "python3": "3.7.1"
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ gitpython<=3.1.41
 urllib3==1.26.19
 opentelemetry-api==1.23.0
 opentelemetry-sdk==1.23.0
+six==1.17.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+cryptography==46.0.3
 azure.storage.blob==12.13.0
 azure.storage.queue==12.4.0
 azure.identity==1.16.1

--- a/scripts/channel_map.py
+++ b/scripts/channel_map.py
@@ -4,7 +4,7 @@ class ChannelMap():
     channel_map = {
         'main': {
             'tfm': 'net10.0',
-            'branch': '10.0',
+            'branch': '11.0',
             'quality': 'daily'
         },
         '10.0': {

--- a/scripts/channel_map.py
+++ b/scripts/channel_map.py
@@ -3,7 +3,7 @@ from typing import Optional
 class ChannelMap():
     channel_map = {
         'main': {
-            'tfm': 'net10.0',
+            'tfm': 'net11.0',
             'branch': '11.0',
             'quality': 'daily'
         },

--- a/scripts/channel_map.py
+++ b/scripts/channel_map.py
@@ -22,6 +22,11 @@ class ChannelMap():
             'branch': '10.0',
             'quality': 'daily'
         },
+        'nativeaot11.0': {
+            'tfm': 'nativeaot11.0',
+            'branch': '11.0',
+            'quality': 'daily'
+        },
         '9.0': {
             'tfm': 'net9.0',
             'branch': '9.0',

--- a/scripts/ci_setup.py
+++ b/scripts/ci_setup.py
@@ -377,6 +377,10 @@ def main(args: CiSetupArgs):
         dotnet.setup_dotnet(args.dotnet_path)
 
     framework = ChannelMap.get_target_framework_moniker(args.channel)
+    if framework in ('net10.0', 'nativeaot10.0'):
+        global_json_path = os.path.join(get_repo_root_path(), 'global.json')
+        shutil.copy(os.path.join(get_repo_root_path(), 'global.net10.json'), global_json_path)
+        getLogger().info('Overwrote global.json with global.net10.json')
     if framework in ('net9.0', 'nativeaot9.0'):
         global_json_path = os.path.join(get_repo_root_path(), 'global.json')
         shutil.copy(os.path.join(get_repo_root_path(), 'global.net9.json'), global_json_path)

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -83,6 +83,8 @@ def get_target_framework_moniker(framework: str) -> str:
         return 'net9.0'
     if framework == 'nativeaot10.0':
         return 'net10.0'
+    if framework == 'nativeaot11.0':
+        return 'net11.0'
     else:
         return framework
 

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -847,7 +847,8 @@ def install(
         'powershell.exe',
         '-NoProfile',
         '-ExecutionPolicy', 'Bypass',
-        dotnetInstallScriptPath
+        '-Command',
+        f'[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12; & "{dotnetInstallScriptPath}"'
     ] if platform == 'win32' else [dotnetInstallScriptPath]
 
     # If Version is supplied, pull down the specified version

--- a/scripts/dotnet.py
+++ b/scripts/dotnet.py
@@ -578,8 +578,9 @@ def get_dotnet_version_from_path(
         sdk = next((f for f in sdks if f.startswith(
             "{}.{}".format(version.major, version.minor + 1))), None)
     if not sdk:
-        if version.major == 9:
-            sdk = next((f for f in sdks if f.startswith("10.0")), None)
+        # Attempt 3: Try to use SDK with major version + 1 (e.g., net9.0 -> SDK 10.0, net10.0 -> SDK 11.0).
+        sdk = next((f for f in sdks if f.startswith(
+            "{}.{}".format(version.major + 1, version.minor))), None)
     if not sdk:
         sdk = next((f for f in sdks if f.startswith(
             "{}.{}".format('6', '0'))), None)

--- a/scripts/micro_benchmarks.py
+++ b/scripts/micro_benchmarks.py
@@ -269,6 +269,8 @@ def __get_benchmarkdotnet_arguments(framework: str, args: Any) -> list[str]:
             run_args += ['--runtimes', 'wasmnet90']
         elif framework == "net10.0":
             run_args += ['--runtimes', 'wasmnet10_0']
+        elif framework == "net11.0":
+            run_args += ['--runtimes', 'wasmnet11_0']
         else:
             raise ArgumentTypeError('Framework {} is not supported for wasm'.format(framework))
 

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -138,7 +138,7 @@ def get_pre_commands(
         # Run inside a python venv
         if os_group == "windows":
             install_prerequisites += [
-                "py -3 -c \"exit(1 if __import__('sys').version_info[:2] == (3, 13) and 'experimental free-threading' in __import__('sys').version.lower() else 0)\" && py -3 -m venv %HELIX_WORKITEM_ROOT%\\.venv || py -3.13 -m venv %HELIX_WORKITEM_ROOT%\\.venv",
+                "(py -3 -c \"exit(1 if __import__('sys').version_info[:2] == (3, 13) and 'experimental free-threading' in __import__('sys').version.lower() else 0)\" && py -3 -m venv %HELIX_WORKITEM_ROOT%\\.venv || py -3.13 -m venv %HELIX_WORKITEM_ROOT%\\.venv)",
                 "call %HELIX_WORKITEM_ROOT%\\.venv\\Scripts\\activate.bat",
                 "echo on" # venv activate script turns echo off, so turn it back on
             ]

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -174,6 +174,7 @@ def get_pre_commands(
         # Install python pacakges needed to upload results to azure storage
         install_prerequisites += [
             f"python -m pip install -U pip",
+            f"python -m pip install cryptography==46.0.3",
             f"python -m pip install azure.storage.blob==12.13.0",
             f"python -m pip install azure.storage.queue==12.4.0",
             f"python -m pip install azure.identity==1.16.1",

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -950,7 +950,9 @@ def run_performance_job(args: RunPerformanceJobArgs):
             "-p:DisableTransitiveFrameworkReferenceDownloads=true"],
             verbose=True).run()
 
-    publish_dotnet_app_to_payload("certhelper", os.path.join(args.performance_repo_dir, "src", "tools", "CertHelper", "CertHelper.csproj"))
+    # Skip publishing CertHelper for WASM runs as a bug is breaking the build https://github.com/dotnet/runtime/issues/120901
+    if not wasm:
+        publish_dotnet_app_to_payload("certhelper", os.path.join(args.performance_repo_dir, "src", "tools", "CertHelper", "CertHelper.csproj"))
 
     if args.is_scenario:
         set_environment_variable("DOTNET_ROOT", ci_setup_arguments.install_dir, save_to_pipeline=True)

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -138,7 +138,7 @@ def get_pre_commands(
         # Run inside a python venv
         if os_group == "windows":
             install_prerequisites += [
-                "py -3 -m venv %HELIX_WORKITEM_ROOT%\\.venv",
+                "py -3 -c \"exit(1 if __import__('sys').version_info[:2] == (3, 13) and 'experimental free-threading' in __import__('sys').version.lower() else 0)\" && py -3 -m venv %HELIX_WORKITEM_ROOT%\\.venv || py -3.13 -m venv %HELIX_WORKITEM_ROOT%\\.venv",
                 "call %HELIX_WORKITEM_ROOT%\\.venv\\Scripts\\activate.bat",
                 "echo on" # venv activate script turns echo off, so turn it back on
             ]

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -171,6 +171,7 @@ def get_pre_commands(
             f"python -m pip install urllib3==1.26.19",
             f"python -m pip install opentelemetry-api==1.23.0",
             f"python -m pip install opentelemetry-sdk==1.23.0",
+            f"python -m pip install six==1.17.0",
         ]
 
         # Install prereqs for NodeJS https://github.com/dotnet/runtime/pull/40667 

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -1010,9 +1010,10 @@ def run_performance_job(args: RunPerformanceJobArgs):
 
             # TODO: See if these commands are needed for linux as they were being called before but were failing.
             if args.os_group == "windows" or args.os_group == "osx":
-                RunCommand([*(agent_python.split(" ")), "-m", "pip", "install", "--user", "--upgrade", "pip"]).run()
-                RunCommand([*(agent_python.split(" ")), "-m", "pip", "install", "--user", "urllib3==1.26.19"]).run()
-                RunCommand([*(agent_python.split(" ")), "-m", "pip", "install", "--user", "requests"]).run()
+                break_system_packages = ["--break-system-packages"] if args.os_group == "osx" else []
+                RunCommand([*(agent_python.split(" ")), "-m", "pip", "install", *break_system_packages, "--user", "--upgrade", "pip"]).run()
+                RunCommand([*(agent_python.split(" ")), "-m", "pip", "install", *break_system_packages, "--user", "urllib3==1.26.19"]).run()
+                RunCommand([*(agent_python.split(" ")), "-m", "pip", "install", *break_system_packages, "--user", "requests"]).run()
 
             scenarios_path = os.path.join(args.performance_repo_dir, "src", "scenarios")
             script_path = os.path.join(args.performance_repo_dir, "scripts")

--- a/scripts/run_performance_job.py
+++ b/scripts/run_performance_job.py
@@ -59,6 +59,7 @@ class RunPerformanceJobArgs:
     run_kind: str
     architecture: str
     os_group: str
+    os_distro: Optional[str] = None
     
     logical_machine: Optional[str] = None
     queue: Optional[str] = None
@@ -118,6 +119,7 @@ class RunPerformanceJobArgs:
 
 def get_pre_commands(
         os_group: str,
+        os_distro: Optional[str],
         internal: bool,
         runtime_type: str,
         codegen_type: str,
@@ -144,12 +146,17 @@ def get_pre_commands(
             ]
         else:
             if os_group != "osx":
-                install_prerequisites += [
-                    'echo "** Waiting for dpkg to unlock (up to 2 minutes) **"',
-                    'timeout 2m bash -c \'while sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do if [ -z "$printed" ]; then echo "Waiting for dpkg lock to be released... Lock is held by: $(ps -o cmd= -p $(sudo fuser /var/lib/dpkg/lock-frontend))"; printed=1; fi; echo "Waiting 5 seconds to check again"; sleep 5; done;\'',
-                    "sudo apt-get remove -y lttng-modules-dkms", # https://github.com/dotnet/runtime/pull/101142
-                    "sudo apt-get -y install python3-pip"
-                ]
+                if os_distro == "azurelinux":
+                    install_prerequisites += [
+                        "sudo tdnf -y install python3-pip"
+                    ]
+                else:
+                    install_prerequisites += [
+                        'echo "** Waiting for dpkg to unlock (up to 2 minutes) **"',
+                        'timeout 2m bash -c \'while sudo fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; do if [ -z "$printed" ]; then echo "Waiting for dpkg lock to be released... Lock is held by: $(ps -o cmd= -p $(sudo fuser /var/lib/dpkg/lock-frontend))"; printed=1; fi; echo "Waiting 5 seconds to check again"; sleep 5; done;\'',
+                        "sudo apt-get remove -y lttng-modules-dkms", # https://github.com/dotnet/runtime/pull/101142
+                        "sudo apt-get -y install python3-pip"
+                    ]
 
             install_prerequisites += [
                 "python3 -m venv $HELIX_WORKITEM_ROOT/.venv",
@@ -179,33 +186,51 @@ def get_pre_commands(
         # Install prereqs for NodeJS https://github.com/dotnet/runtime/pull/40667 
         # TODO: is this still needed? It seems like it was added to support wasm which is already setting up everything
         if os_group != "windows" and os_group != "osx":
-            install_prerequisites += [
-                "sudo apt-get update",
-                "sudo apt -y install curl dirmngr apt-transport-https lsb-release ca-certificates"
-            ]
+            if os_distro == "azurelinux":
+                install_prerequisites += [
+                    "sudo tdnf -y install curl ca-certificates"
+                ]
+            else:
+                install_prerequisites += [
+                    "sudo apt-get update",
+                    "sudo apt -y install curl dirmngr apt-transport-https lsb-release ca-certificates"
+                ]
 
     # Set up everything needed for WASM runs
-    if runtime_type == "wasm":
-        # nodejs installation steps from https://github.com/nodesource/distributions
-        install_prerequisites += [
-            "export RestoreAdditionalProjectSources=$HELIX_CORRELATION_PAYLOAD/built-nugets",
-            "sudo apt-get -y remove nodejs",
-            "sudo apt-get update",
-            "sudo apt-get install -y ca-certificates curl gnupg",
-            "sudo mkdir -p /etc/apt/keyrings",
-            "sudo rm -f /etc/apt/keyrings/nodesource.gpg",
-            "curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor --batch -o /etc/apt/keyrings/nodesource.gpg",
-            "export NODE_MAJOR=18",
-            "echo \"deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main\" | sudo tee /etc/apt/sources.list.d/nodesource.list",
-            "sudo apt-get update",
-            "sudo apt autoremove -y",
-            "sudo apt-get install nodejs -y",
-            f"test -n \"{v8_version}\"",
-            "npm install --prefix $HELIX_WORKITEM_ROOT jsvu -g",
-            f"$HELIX_WORKITEM_ROOT/bin/jsvu --os=linux64 v8@{v8_version}",
-            f"export V8_ENGINE_PATH=~/.jsvu/bin/v8-{v8_version}",
-            "${V8_ENGINE_PATH} -e 'console.log(`V8 version: ${this.version()}`)'"
-        ]
+    if runtime_type == "wasm":  
+        if os_distro == "azurelinux":
+            # Azure Linux uses tdnf package manager
+            install_prerequisites += [
+                "export RestoreAdditionalProjectSources=$HELIX_CORRELATION_PAYLOAD/built-nugets",
+                "sudo tdnf -y update",
+                "sudo tdnf -y remove nodejs",
+                "sudo tdnf -y install ca-certificates curl gnupg nodejs npm",
+                f"test -n \"{v8_version}\"",
+                "npm install --prefix $HELIX_WORKITEM_ROOT jsvu -g",
+                f"$HELIX_WORKITEM_ROOT/bin/jsvu --os=linux64 v8@{v8_version}",
+                f"export V8_ENGINE_PATH=~/.jsvu/bin/v8-{v8_version}",
+                "${V8_ENGINE_PATH} -e 'console.log(`V8 version: ${this.version()}`)'"
+            ]
+        else:
+            install_prerequisites += [
+                "export RestoreAdditionalProjectSources=$HELIX_CORRELATION_PAYLOAD/built-nugets",
+                "sudo apt-get -y remove nodejs",
+                "sudo apt-get update",
+                "sudo apt-get install -y ca-certificates curl gnupg",
+                "sudo mkdir -p /etc/apt/keyrings",
+                "sudo rm -f /etc/apt/keyrings/nodesource.gpg",
+                "curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | sudo gpg --dearmor --batch -o /etc/apt/keyrings/nodesource.gpg",
+                "export NODE_MAJOR=18",
+                "echo \"deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main\" | sudo tee /etc/apt/sources.list.d/nodesource.list",
+                "sudo apt-get update",
+                "sudo apt autoremove -y",
+                "sudo apt-get install nodejs -y",
+                f"test -n \"{v8_version}\"",
+                "npm install --prefix $HELIX_WORKITEM_ROOT jsvu -g",
+                f"$HELIX_WORKITEM_ROOT/bin/jsvu --os=linux64 v8@{v8_version}",
+                f"export V8_ENGINE_PATH=~/.jsvu/bin/v8-{v8_version}",
+                "${V8_ENGINE_PATH} -e 'console.log(`V8 version: ${this.version()}`)'"
+            ]
 
     # Add the install_prerequisites to the pre_commands
     if os_group == "windows":
@@ -330,6 +355,7 @@ def logical_machine_to_queue(logical_machine: str, internal: bool, os_group: str
         else:
             queue_map = {
                 "perfampere": "Ubuntu.2204.Arm64.Perf",
+                "perfcobalt": "AzureLinux.3.Cobalt.Arm64.Perf",
                 "perfiphone12mini": "OSX.13.Amd64.Iphone.Perf",
                 "perftiger_crossgen": "Ubuntu.1804.Amd64.Tiger.Perf",
                 "perfviper": "Ubuntu.2204.Amd64.Viper.Perf",
@@ -899,7 +925,7 @@ def run_performance_job(args: RunPerformanceJobArgs):
     else:
         agent_python = "python3"
 
-    helix_pre_commands = get_pre_commands(args.os_group, args.internal, args.runtime_type, args.codegen_type, v8_version)
+    helix_pre_commands = get_pre_commands(args.os_group, args.os_distro, args.internal, args.runtime_type, args.codegen_type, v8_version)
     helix_post_commands = get_post_commands(args.os_group, args.internal, args.runtime_type)
 
     ci_setup_arguments.local_build = args.local_build
@@ -1259,6 +1285,7 @@ def main(argv: list[str]):
                 "--affinity": "affinity",
                 "--os-group": "os_group",
                 "--os-sub-group": "os_sub_group",
+                "--os-distro": "os_distro",
                 "--runtime-flavor": "runtime_flavor",
                 "--javascript-engine": "javascript_engine",
                 "--experiment-name": "experiment_name",

--- a/scripts/upload.py
+++ b/scripts/upload.py
@@ -25,7 +25,7 @@ class QueueMessage:
 def get_unique_name(filename: str, unique_id: str) -> str:
     newname = "{0}-{1}".format(unique_id, os.path.basename(filename))
     if len(newname) > 1024:
-        newname = "{0}-perf-lab-report.json".format(randint(1000, 9999))
+        newname = "{0}-{1}-perf-lab-report.json".format(unique_id, randint(1000, 9999))
     return newname
 
 def get_credential():

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -244,6 +244,10 @@
     <Compile Remove="libraries\System.Reflection.Metadata\*.cs" />
   </ItemGroup>
 
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net11.0'))">
+    <Compile Remove="libraries\System.IO.Compression\Zstandard.cs" />
+  </ItemGroup>
+
   <!-- Remove Sve microbenchmarks when running on net versions < 9.0 -->
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0'))">
     <Compile Remove="sve\*.cs" />

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -57,6 +57,13 @@
     </When>
     <When Condition="'$(TargetFramework)' == 'net10.0'">
         <PropertyGroup>
+            <LangVersion>14</LangVersion>
+            <ExtensionsVersion>10.0.0</ExtensionsVersion>
+            <SystemVersion>10.0.0</SystemVersion>
+        </PropertyGroup>
+    </When>
+    <When Condition="'$(TargetFramework)' == 'net11.0'">
+        <PropertyGroup>
             <LangVersion>preview</LangVersion>
             <ExtensionsVersion>$(MicrosoftExtensionsLoggingPackageVersion)</ExtensionsVersion>
             <SystemVersion>$(SystemThreadingChannelsPackageVersion)</SystemVersion>

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <!-- Supported target frameworks -->
-    <SupportedTargetFrameworks>net6.0;net7.0;net8.0;net9.0;net10.0</SupportedTargetFrameworks>
+    <SupportedTargetFrameworks>net6.0;net7.0;net8.0;net9.0;net10.0;net11.0</SupportedTargetFrameworks>
     <SupportedTargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(SupportedTargetFrameworks);net472</SupportedTargetFrameworks>
     <!-- Used by Python script to narrow down the specified target frameworks to test, and avoid downloading all supported SDKs -->
     <TargetFrameworks>$(PERFLAB_TARGET_FRAMEWORKS)</TargetFrameworks>

--- a/src/benchmarks/micro/MicroBenchmarks.csproj
+++ b/src/benchmarks/micro/MicroBenchmarks.csproj
@@ -10,6 +10,8 @@
     <NoWarn>$(NoWarn);CS8002</NoWarn>
     <!-- Suppress binaryformatter obsolete warning -->
     <NoWarn>$(NoWarn);SYSLIB0011</NoWarn>
+    <!-- Suppress Sve experimental feature warning -->
+    <NoWarn>$(NoWarn);SYSLIB5003</NoWarn>
     <OutputType>Exe</OutputType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugType>portable</DebugType>

--- a/src/benchmarks/micro/Program.cs
+++ b/src/benchmarks/micro/Program.cs
@@ -45,7 +45,7 @@ namespace MicroBenchmarks
                 .Run(argsList.ToArray(), 
                     RecommendedConfig.Create(
                         artifactsPath: new DirectoryInfo(Path.Combine(AppContext.BaseDirectory, "BenchmarkDotNet.Artifacts")), 
-                        mandatoryCategories: ImmutableHashSet.Create(Categories.Libraries, Categories.Runtime, Categories.ThirdParty),
+                        mandatoryCategories: ImmutableHashSet.Create([Categories.Libraries, Categories.Runtime, Categories.ThirdParty]),
                         partitionCount: partitionCount,
                         partitionIndex: partitionIndex,
                         exclusionFilterValue: exclusionFilterValue,

--- a/src/benchmarks/micro/Properties/AssemblyInfo.cs
+++ b/src/benchmarks/micro/Properties/AssemblyInfo.cs
@@ -20,7 +20,7 @@ namespace MicroBenchmarks
                 ? ManualConfig.CreateEmpty()
                 : RecommendedConfig.Create(
                     artifactsPath: new DirectoryInfo(Path.Combine(AppContext.BaseDirectory, "BenchmarkDotNet.Artifacts")),
-                    mandatoryCategories: ImmutableHashSet.Create(Categories.Libraries, Categories.Runtime, Categories.ThirdParty));
+                    mandatoryCategories: ImmutableHashSet.Create([Categories.Libraries, Categories.Runtime, Categories.ThirdParty]));
         }
 
         public IConfig Config { get; }

--- a/src/benchmarks/micro/README.md
+++ b/src/benchmarks/micro/README.md
@@ -12,38 +12,38 @@ To learn more about designing benchmarks, please read [Microbenchmark Design Gui
 
 ## Quick Start
 
-The first thing that you need to choose is the Target Framework. Available options are: `netcoreapp3.1|net6.0|net7.0|net8.0|net9.0|net10.0|net472`. You can specify the target framework using `-f|--framework` argument. For the sake of simplicity, all examples below use `net10.0` as the target framework.
+The first thing that you need to choose is the Target Framework. Available options are: `netcoreapp3.1|net6.0|net7.0|net8.0|net9.0|net10.0|net11.0|net472`. You can specify the target framework using `-f|--framework` argument. For the sake of simplicity, all examples below use `net11.0` as the target framework.
 
 The following commands are run from the `src/benchmarks/micro` directory.
 
 To run the benchmarks in Interactive Mode, where you will be asked which benchmark(s) to run:
 
 ```cmd
-dotnet run -c Release -f net10.0
+dotnet run -c Release -f net11.0
 ```
 
 To list all available benchmarks ([read more](../../../docs/benchmarkdotnet.md#Listing-the-Benchmarks)):
 
 ```cmd
-dotnet run -c Release -f net10.0 --list flat|tree
+dotnet run -c Release -f net11.0 --list flat|tree
 ```
 
 To filter the benchmarks using a glob pattern applied to namespace.typeName.methodName ([read more](../../../docs/benchmarkdotnet.md#Filtering-the-Benchmarks)):
 
 ```cmd
-dotnet run -c Release -f net10.0 --filter *Span*
+dotnet run -c Release -f net11.0 --filter *Span*
 ```
 
 To profile the benchmarked code and produce an ETW Trace file ([read more](../../../docs/benchmarkdotnet.md#Profiling)):
 
 ```cmd
-dotnet run -c Release -f net10.0 --filter $YourFilter --profiler ETW
+dotnet run -c Release -f net11.0 --filter $YourFilter --profiler ETW
 ```
 
 To run the benchmarks for multiple runtimes ([read more](../../../docs/benchmarkdotnet.md#Multiple-Runtimes)):
 
 ```cmd
-dotnet run -c Release -f net8.0 --filter * --runtimes net8.0 net10.0
+dotnet run -c Release -f net10.0 --filter * --runtimes net10.0 net11.0
 ```
 
 ## Private Runtime Builds
@@ -51,14 +51,14 @@ dotnet run -c Release -f net8.0 --filter * --runtimes net8.0 net10.0
 If you contribute to [dotnet/runtime](https://github.com/dotnet/runtime) and want to benchmark **local builds of .NET Core** you need to build [dotnet/runtime](https://github.com/dotnet/runtime) in Release (including tests - so a command similar to `build clr+libs+libs.tests -rc release -lc release`) and then provide the path(s) to CoreRun(s). Provided CoreRun(s) will be used to execute every benchmark in a dedicated process:
 
 ```cmd
-dotnet run -c Release -f net10.0 --filter $YourFilter \
+dotnet run -c Release -f net11.0 --filter $YourFilter \
     --corerun C:\git\runtime\artifacts\bin\testhost\net10.0-windows-Release-x64\shared\Microsoft.NETCore.App\9.0.0\CoreRun.exe
 ```
 
 To make sure that your changes don't introduce any regressions, you can provide paths to CoreRuns with and without your changes and use the Statistical Test feature to detect regressions/improvements ([read more](../../../docs/benchmarkdotnet.md#Regressions)):
 
 ```cmd
-dotnet run -c Release -f net10.0 \
+dotnet run -c Release -f net11.0 \
     --filter BenchmarksGame* \
     --statisticalTest 3ms \
     --coreRun \

--- a/src/benchmarks/micro/libraries/System.Collections/Concurrent/AddRemoveFromDifferentThreads.cs
+++ b/src/benchmarks/micro/libraries/System.Collections/Concurrent/AddRemoveFromDifferentThreads.cs
@@ -7,16 +7,24 @@ using System.Threading;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Attributes.Filters;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Filters;
 using MicroBenchmarks;
 
 namespace System.Collections.Concurrent
 {
+    internal class AddRemoveFromDifferentThreadsDisabledConfig : ManualConfig
+    {
+        public AddRemoveFromDifferentThreadsDisabledConfig() => AddFilter(new SimpleFilter(_ => false));
+    }
+
     [BenchmarkCategory(Categories.Libraries, Categories.Collections, Categories.GenericCollections, Categories.NoWASM)]
     [GenericTypeArguments(typeof(int))] // value type
     [GenericTypeArguments(typeof(string))] // reference type
     [MinWarmupCount(6, forceAutoWarmup: true)]
     [MaxWarmupCount(10, forceAutoWarmup: true)]
     [AotFilter("It hangs. https://github.com/dotnet/runtime/issues/66987")]
+    [Config(typeof(AddRemoveFromDifferentThreadsDisabledConfig))]
     public class AddRemoveFromDifferentThreads<T>
     {
         const int NumThreads = 2;

--- a/src/benchmarks/micro/libraries/System.Collections/Concurrent/AddRemoveFromSameThreads.cs
+++ b/src/benchmarks/micro/libraries/System.Collections/Concurrent/AddRemoveFromSameThreads.cs
@@ -6,15 +6,23 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Filters;
 using MicroBenchmarks;
 
 namespace System.Collections.Concurrent
 {
+    internal class AddRemoveFromSameThreadsDisabledConfig : ManualConfig
+    {
+        public AddRemoveFromSameThreadsDisabledConfig() => AddFilter(new SimpleFilter(_ => false));
+    }
+
     [BenchmarkCategory(Categories.Libraries, Categories.Collections, Categories.GenericCollections, Categories.NoWASM)]
     [GenericTypeArguments(typeof(int))] // value type
     [GenericTypeArguments(typeof(string))] // reference type
     [MinWarmupCount(6, forceAutoWarmup: true)]
     [MaxWarmupCount(10, forceAutoWarmup: true)]
+    [Config(typeof(AddRemoveFromSameThreadsDisabledConfig))]
     public class AddRemoveFromSameThreads<T>
     {
         const int NumThreads = 2;

--- a/src/benchmarks/micro/libraries/System.IO.Compression/Brotli.cs
+++ b/src/benchmarks/micro/libraries/System.IO.Compression/Brotli.cs
@@ -12,8 +12,8 @@ namespace System.IO.Compression
     {
         private const int Window = 22;
 
-        public override Stream CreateStream(Stream stream, CompressionMode mode) => new BrotliStream(stream, mode);
-        public override Stream CreateStream(Stream stream, CompressionLevel level) => new BrotliStream(stream, level);
+        public override Stream CreateStream(Stream stream, CompressionMode mode, bool leaveOpen) => new BrotliStream(stream, mode, leaveOpen);
+        public override Stream CreateStream(Stream stream, CompressionLevel level, bool leaveOpen) => new BrotliStream(stream, level, leaveOpen);
 
         [Benchmark]
         public Span<byte> Compress_WithState()
@@ -24,7 +24,7 @@ namespace System.IO.Compression
                 ReadOnlySpan<byte> input = CompressedFile.UncompressedData;
                 while (!input.IsEmpty && !output.IsEmpty)
                 {
-                    encoder.Compress(input, output, out int bytesConsumed, out int written, isFinalBlock:false);
+                    encoder.Compress(input, output, out int bytesConsumed, out int written, isFinalBlock: false);
                     input = input.Slice(bytesConsumed);
                     output = output.Slice(written);
                 }
@@ -64,7 +64,7 @@ namespace System.IO.Compression
         [Benchmark]
         public bool Decompress_WithoutState() // the level argument is not used here, but it describes how the data was compressed (in the benchmark id)
             => BrotliDecoder.TryDecompress(CompressedFile.CompressedData, CompressedFile.UncompressedData, out int bytesWritten);
-        
+
         private static int GetQuality(CompressionLevel compressLevel)
             => compressLevel == CompressionLevel.Optimal ? 11 : compressLevel == CompressionLevel.Fastest ? 1 : 0;
     }

--- a/src/benchmarks/micro/libraries/System.IO.Compression/CompressionStreamPerfTestBase.cs
+++ b/src/benchmarks/micro/libraries/System.IO.Compression/CompressionStreamPerfTestBase.cs
@@ -10,21 +10,21 @@ namespace System.IO.Compression
 {
     public class Gzip : CompressionStreamPerfTestBase
     {
-        public override Stream CreateStream(Stream stream, CompressionMode mode) => new GZipStream(stream, mode);
-        public override Stream CreateStream(Stream stream, CompressionLevel level) => new GZipStream(stream, level);
+        public override Stream CreateStream(Stream stream, CompressionMode mode, bool leaveOpen) => new GZipStream(stream, mode, leaveOpen);
+        public override Stream CreateStream(Stream stream, CompressionLevel level, bool leaveOpen) => new GZipStream(stream, level, leaveOpen);
     }
 
     public class Deflate : CompressionStreamPerfTestBase
     {
-        public override Stream CreateStream(Stream stream, CompressionMode mode) => new DeflateStream(stream, mode);
-        public override Stream CreateStream(Stream stream, CompressionLevel level) => new DeflateStream(stream, level);
+        public override Stream CreateStream(Stream stream, CompressionMode mode, bool leaveOpen) => new DeflateStream(stream, mode, leaveOpen);
+        public override Stream CreateStream(Stream stream, CompressionLevel level, bool leaveOpen) => new DeflateStream(stream, level, leaveOpen);
     }
 
 #if NET6_0_OR_GREATER // API introduced in .NET 6
     public class ZLib : CompressionStreamPerfTestBase
     {
-        public override Stream CreateStream(Stream stream, CompressionMode mode) => new ZLibStream(stream, mode);
-        public override Stream CreateStream(Stream stream, CompressionLevel level) => new ZLibStream(stream, level);
+        public override Stream CreateStream(Stream stream, CompressionMode mode, bool leaveOpen) => new ZLibStream(stream, mode, leaveOpen);
+        public override Stream CreateStream(Stream stream, CompressionLevel level, bool leaveOpen) => new ZLibStream(stream, level, leaveOpen);
     }
 #endif
 
@@ -33,8 +33,8 @@ namespace System.IO.Compression
     [BenchmarkCategory(Categories.Libraries, Categories.NoWASM)]
     public abstract class CompressionStreamPerfTestBase
     {
-        public abstract Stream CreateStream(Stream stream, CompressionMode mode);
-        public abstract Stream CreateStream(Stream stream, CompressionLevel level);
+        public abstract Stream CreateStream(Stream stream, CompressionMode mode, bool leaveOpen = true);
+        public abstract Stream CreateStream(Stream stream, CompressionLevel level, bool leaveOpen = true);
 
         [ParamsSource(nameof(UncompressedTestFileNames))]
         public string file { get; set; }
@@ -59,7 +59,7 @@ namespace System.IO.Compression
         {
             CompressedFile.CompressedDataStream.Position = 0; // all benchmarks invocation reuse the same stream, we set Postion to 0 to start at the beginning
 
-            var compressor = CreateStream(CompressedFile.CompressedDataStream, level);
+            using var compressor = CreateStream(CompressedFile.CompressedDataStream, level);
             compressor.Write(CompressedFile.UncompressedData, 0, CompressedFile.UncompressedData.Length);
         }
 
@@ -68,7 +68,7 @@ namespace System.IO.Compression
         {
             CompressedFile.CompressedDataStream.Position = 0;
 
-            var compressor = CreateStream(CompressedFile.CompressedDataStream, CompressionMode.Decompress);
+            using var compressor = CreateStream(CompressedFile.CompressedDataStream, CompressionMode.Decompress);
 
             byte[] buffer = CompressedFile.UncompressedData;
 

--- a/src/benchmarks/micro/libraries/System.IO.Compression/Zstandard.cs
+++ b/src/benchmarks/micro/libraries/System.IO.Compression/Zstandard.cs
@@ -1,0 +1,71 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace System.IO.Compression
+{
+    [BenchmarkCategory(Categories.Libraries, Categories.NoWASM)]
+    public class Zstandard : CompressionStreamPerfTestBase
+    {
+        private const int Window = 22;
+
+        public override Stream CreateStream(Stream stream, CompressionMode mode, bool leaveOpen) => new ZstandardStream(stream, mode, leaveOpen);
+        public override Stream CreateStream(Stream stream, CompressionLevel level, bool leaveOpen) => new ZstandardStream(stream, level, leaveOpen);
+
+        [Benchmark]
+        public Span<byte> Compress_WithState()
+        {
+            using (ZstandardEncoder encoder = new ZstandardEncoder(GetQuality(level), Window))
+            {
+                Span<byte> output = new Span<byte>(CompressedFile.CompressedData);
+                ReadOnlySpan<byte> input = CompressedFile.UncompressedData;
+                while (!input.IsEmpty && !output.IsEmpty)
+                {
+                    encoder.Compress(input, output, out int bytesConsumed, out int written, isFinalBlock: false);
+                    input = input.Slice(bytesConsumed);
+                    output = output.Slice(written);
+                }
+                encoder.Compress(input, output, out int bytesConsumed2, out int written2, isFinalBlock: true);
+
+                return output;
+            }
+        }
+
+        [Benchmark]
+        public Span<byte> Decompress_WithState() // the level argument is not used here, but it describes how the data was compressed (in the benchmark id)
+        {
+            using (ZstandardDecoder decoder = new ZstandardDecoder())
+            {
+                Span<byte> output = new Span<byte>(CompressedFile.UncompressedData);
+                ReadOnlySpan<byte> input = CompressedFile.CompressedData;
+                while (!input.IsEmpty && !output.IsEmpty)
+                {
+                    decoder.Decompress(input, output, out int bytesConsumed, out int written);
+                    input = input.Slice(bytesConsumed);
+                    output = output.Slice(written);
+                }
+
+                return output;
+            }
+        }
+
+        [Benchmark]
+        [MemoryRandomization]
+        public bool Compress_WithoutState()
+            => ZstandardEncoder.TryCompress(CompressedFile.UncompressedData, CompressedFile.CompressedData, out int bytesWritten, GetQuality(level), Window);
+
+        /// <summary>
+        /// The perf tests for the instant decompression aren't exactly indicative of real-world scenarios since they require you to know 
+        /// either the exact figure or the upper bound of the uncompressed size of your given compressed data.
+        /// </summary>
+        [Benchmark]
+        public bool Decompress_WithoutState() // the level argument is not used here, but it describes how the data was compressed (in the benchmark id)
+            => ZstandardDecoder.TryDecompress(CompressedFile.CompressedData, CompressedFile.UncompressedData, out int bytesWritten);
+
+        private static int GetQuality(CompressionLevel compressLevel)
+            => compressLevel == CompressionLevel.Optimal ? 11 : compressLevel == CompressionLevel.Fastest ? 1 : 0;
+    }
+}

--- a/src/benchmarks/micro/libraries/System.Runtime/Perf.Uri.cs
+++ b/src/benchmarks/micro/libraries/System.Runtime/Perf.Uri.cs
@@ -67,7 +67,7 @@ namespace System.Tests
         public string ParseAbsoluteUri() => new Uri("http://127.0.0.1:80").AbsoluteUri;
 
         [Benchmark]
-        public string DnsSafeHost() => new Uri("http://[fe80::3]%1").DnsSafeHost;
+        public string DnsSafeHost() => new Uri("http://[fe80::3%251]").DnsSafeHost;
 
         [Benchmark]
         [MemoryRandomization]

--- a/src/benchmarks/micro/libraries/System.Text.RegularExpressions/Perf.Regex.LeadingStrings.cs
+++ b/src/benchmarks/micro/libraries/System.Text.RegularExpressions/Perf.Regex.LeadingStrings.cs
@@ -1,0 +1,112 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using BenchmarkDotNet.Attributes;
+using MicroBenchmarks;
+
+namespace System.Text.RegularExpressions.Tests
+{
+    /// <summary>
+    /// Performance tests for regex alternation patterns on binary data.
+    /// Exercises the LeadingStrings vs FixedDistanceSets heuristic on non-text input.
+    /// </summary>
+    [BenchmarkCategory(Categories.Libraries, Categories.Regex, Categories.NoWASM)]
+    public class Perf_Regex_LeadingStrings_BinaryData
+    {
+        [Params(
+            RegexOptions.None,
+            RegexOptions.Compiled
+#if NET7_0_OR_GREATER
+            , RegexOptions.NonBacktracking
+#endif
+            )]
+        public RegexOptions Options { get; set; }
+
+        private string _binaryText;
+        private Regex _regex;
+
+        // A small embedded binary-like fragment (~64 bytes) containing null bytes and typical PE patterns,
+        // duplicated in Setup to create a ~1MB corpus. Using a fixed seed ensures identical input across TFMs.
+        private static readonly byte[] s_binarySeed =
+        {
+            0x4D, 0x5A, 0x90, 0x00, 0x03, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00, 0x00, 0xFF, 0xFF, 0x00, 0x00,
+            0xB8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x50, 0x45, 0x00, 0x00, 0x64, 0x86, 0x02, 0x00, 0x48, 0x65, 0x6C, 0x6C, 0x6F, 0x00, 0x00, 0x00,
+            0x2E, 0x74, 0x65, 0x78, 0x74, 0x00, 0x00, 0x00, 0x2E, 0x72, 0x73, 0x72, 0x63, 0x00, 0x00, 0x00,
+        };
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            // Duplicate the seed to ~1MB
+            const int targetSize = 1024 * 1024;
+            char[] chars = new char[targetSize];
+            for (int i = 0; i < targetSize; i++)
+                chars[i] = (char)s_binarySeed[i % s_binarySeed.Length];
+            _binaryText = new string(chars);
+
+            // Alternation of 4-byte sequences that appear in the seed (non-null starting)
+            _regex = new Regex(@"MZ\x90\x00|PE\x00\x00|\.text|\.rsrc|Hello|d\x86\x02\x00", Options);
+        }
+
+        [Benchmark]
+        [MemoryRandomization]
+        public int Count() => Perf_Regex_Industry.Count(_regex, _binaryText);
+    }
+
+    /// <summary>
+    /// Performance tests for regex alternation patterns on non-ASCII text (Russian).
+    /// </summary>
+    [BenchmarkCategory(Categories.Libraries, Categories.Regex, Categories.NoWASM)]
+    public class Perf_Regex_LeadingStrings_NonAscii
+    {
+        [Params(
+            RegexOptions.None,
+            RegexOptions.Compiled
+#if NET7_0_OR_GREATER
+            , RegexOptions.NonBacktracking
+#endif
+            )]
+        public RegexOptions Options { get; set; }
+
+        private string _input;
+        private Regex _alternation;
+        private Regex _alternationIgnoreCase;
+
+        // Opening of Anna Karenina (Tolstoy), ~1KB of natural Russian prose.
+        // "All happy families are alike; each unhappy family is unhappy in its own way.
+        //  Everything was in confusion in the Oblonskys' house. The wife had discovered that the husband
+        //  was carrying on an intrigue with their former French governess, and she had announced to her
+        //  husband that she could not go on living in the same house with him..."
+        private const string Text =
+            "Все счастливые семьи похожи друг на друга, каждая несчастливая семья несчастлива по-своему. " +
+            "Всё смешалось в доме Облонских. Жена узнала, что муж был в связи с бывшею в их доме француженкою-гувернанткой, " +
+            "и объявила мужу, что не может жить с ним в одном доме. Положение это продолжалось уже третий день и чувствовалось " +
+            "и самими супругами, и всеми членами семьи, и домочадцами. Все члены семьи и домочадцы чувствовали, что нет смысла " +
+            "в их сожительстве и что на каждом постоялом дворе случайно сошедшиеся люди более связаны между собой, чем они, " +
+            "члены семьи и домочадцы Облонских. Жена не выходила из своих комнат, мужа третий день не было дома. " +
+            "Дети бегали по всему дому, как потерянные; англичанка поссорилась с экономкой и написала записку приятельнице, " +
+            "прося приискать ей новое место; повар ушёл ещё вчера со двора, во время обеда; чёрная кухарка и кучер просили расчёт.";
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var sb = new System.Text.StringBuilder(100000);
+            for (int i = 0; i < 100; i++)
+                sb.Append(Text);
+            _input = sb.ToString();
+
+            _alternation = new Regex("семьи|Облонских|француженкою|домочадцами|сожительстве|англичанка|экономкой|кухарка", Options);
+            _alternationIgnoreCase = new Regex("(?i)семьи|Облонских|француженкою|домочадцами|сожительстве|англичанка|экономкой|кухарка", Options);
+        }
+
+        [Benchmark]
+        [MemoryRandomization]
+        public int Count() => Perf_Regex_Industry.Count(_alternation, _input);
+
+        [Benchmark]
+        [MemoryRandomization]
+        public int CountIgnoreCase() => Perf_Regex_Industry.Count(_alternationIgnoreCase, _input);
+    }
+}

--- a/src/benchmarks/micro/sve/AddReduction.cs
+++ b/src/benchmarks/micro/sve/AddReduction.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Diagnostics;
+using System.Numerics;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Extensions;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Filters;
+using MicroBenchmarks;
+
+namespace SveBenchmarks
+{
+    [BenchmarkCategory(Categories.Runtime)]
+    [OperatingSystemsArchitectureFilter(allowed: true, System.Runtime.InteropServices.Architecture.Arm64)]
+    [Config(typeof(Config))]
+    public class AddReduction
+    {
+        private class Config : ManualConfig
+        {
+            public Config()
+            {
+                AddFilter(new SimpleFilter(_ => Sve.IsSupported));
+            }
+        }
+
+        [Params(15, 127, 527, 10015)]
+        public int Size;
+
+        private double[] _source;
+        private double _result;
+
+        [GlobalSetup]
+        public virtual void Setup()
+        {
+            _source = ValuesGenerator.Array<double>(Size);
+        }
+
+        [GlobalCleanup]
+        public virtual void Verify()
+        {
+            double current = _result;
+            Setup();
+            Scalar();
+            double scalar = _result;
+            // Check that the result is the same as scalar (within 10ULP).
+            // Error is due to rounding floating-point additions in different
+            // orderings (for Vector128AddReduction and SveAddReduction).
+            // SveAddSequential has the same ordering as Scalar.
+            int e = (int)(BitConverter.DoubleToUInt64Bits(scalar) >> 52 & 0x7ff);
+            if (e == 0) e++;
+            double ulpScale = Math.ScaleB(1.0f, e - 1023 - 52);
+            double ulpError = Math.Abs(current - scalar) / ulpScale;
+            Debug.Assert(ulpError <= 10);
+        }
+
+        [Benchmark]
+        public unsafe void Scalar()
+        {
+            fixed (double* a = _source)
+            {
+                double res = 0.0;
+                for (int i = 0; i < Size; i++)
+                {
+                    res += a[i];
+                }
+                _result = res;
+            }
+        }
+
+        [Benchmark]
+        public unsafe void Vector128AddReduction()
+        {
+            fixed (double* a = _source)
+            {
+                int i = 0;
+                double res = 0.0;
+                for (; i <= Size - 2; i += 2)
+                {
+                    Vector128<double> data = AdvSimd.LoadVector128(a + i);
+                    // Sum up all lanes and reduce to scalar.
+                    res += AdvSimd.Arm64.AddPairwiseScalar(data).ToScalar();
+                }
+                // Handle Tail.
+                for (; i < Size; i++)
+                {
+                    res += a[i];
+                }
+                _result = res;
+            }
+        }
+
+        [Benchmark]
+        public unsafe void SveAddSequential()
+        {
+            fixed (double* a = _source)
+            {
+                int i = 0;
+                int cntd = (int)Sve.Count64BitElements();
+
+                Vector<double> resVec = Vector<double>.Zero;
+                Vector<double> pTrue = Sve.CreateTrueMaskDouble();
+                for (; i <= Size - cntd; i += cntd)
+                {
+                    Vector<double> data = Sve.LoadVector(pTrue, a + i);
+                    // Sum up all lanes sequentially and add to scalar.
+                    resVec = Sve.AddSequentialAcross(resVec, data);
+                }
+                // Get the scalar result from the first lane.
+                double res = resVec.ToScalar();
+                // Handle Tail.
+                for (; i < Size; i++)
+                {
+                    res += a[i];
+                }
+                _result = res;
+            }
+        }
+
+        [Benchmark]
+        public unsafe void SveAddReduction()
+        {
+            fixed (double* a = _source)
+            {
+                int i = 0;
+                int cntd = (int)Sve.Count64BitElements();
+                double res = 0.0;
+
+                Vector<double> pTrue = Sve.CreateTrueMaskDouble();
+                for (; i <= Size - cntd; i += cntd)
+                {
+                    Vector<double> data = Sve.LoadVector(pTrue, a + i);
+                    // Sum up all lanes and reduce to scalar.
+                    res += Sve.AddAcross(data).ToScalar();
+                }
+                // Handle Tail.
+                for (; i < Size; i++)
+                {
+                    res += a[i];
+                }
+                _result = res;
+            }
+        }
+    }
+}

--- a/src/benchmarks/micro/sve/Logarithm.cs
+++ b/src/benchmarks/micro/sve/Logarithm.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Diagnostics;
+using System.Numerics;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Extensions;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Filters;
+using MicroBenchmarks;
+
+namespace SveBenchmarks
+{
+    [BenchmarkCategory(Categories.Runtime)]
+    [OperatingSystemsArchitectureFilter(allowed: true, System.Runtime.InteropServices.Architecture.Arm64)]
+    [Config(typeof(Config))]
+    public class Logarithm
+    {
+        private class Config : ManualConfig
+        {
+            public Config()
+            {
+                AddFilter(new SimpleFilter(_ => Sve.IsSupported));
+            }
+        }
+
+        [Params(15, 127, 527, 10015)]
+        public int Size;
+
+        private float[] _input;
+        private float[] _data;
+        private float[] _output;
+
+        [GlobalSetup]
+        public virtual void Setup()
+        {
+            Random rand = new Random(0);
+            _input = new float[Size];
+            for (int i = 0; i < Size; i++)
+            {
+                _input[i] = (float)(rand.NextDouble() * (double)Size);
+            }
+
+            // Coefficients taken from Arm Optimized-Routines.
+            // https://github.com/ARM-software/optimized-routines/blob/v25.07/math/aarch64/advsimd/logf.c
+            _data = new float[8]{
+                // p0, p1, p3, p5
+                BitConverter.UInt32BitsToSingle(0xbe1f39be),
+                BitConverter.UInt32BitsToSingle(0x3e2d4d51),
+                BitConverter.UInt32BitsToSingle(0x3e4b09a4),
+                BitConverter.UInt32BitsToSingle(0x3eaaaebe),
+                // p2, p4, p6, ln2
+                BitConverter.UInt32BitsToSingle(0xbe27cc9a),
+                BitConverter.UInt32BitsToSingle(0xbe800c3e),
+                BitConverter.UInt32BitsToSingle(0xbeffffe4),
+                BitConverter.UInt32BitsToSingle(0x3f317218),
+            };
+
+            _output = new float[Size];
+        }
+
+        [GlobalCleanup]
+        public virtual void Verify()
+        {
+            float[] current = (float[])_output.Clone();
+            Setup();
+            Scalar();
+            float[] scalar = (float[])_output.Clone();
+            // Check that the result is the same as scalar (within 3ULP).
+            for (int i = 0; i < Size; i++)
+            {
+                int e = (int)(BitConverter.SingleToUInt32Bits(scalar[i]) >> 23 & 0xff);
+                if (e == 0) e++;
+                float ulpScale = (float)Math.ScaleB(1.0, e - 127 - 23);
+                float ulpError = (float)Math.Abs(current[i] - scalar[i]) / ulpScale;
+                Debug.Assert(ulpError <= 3);
+            }
+        }
+
+        [Benchmark]
+        public unsafe void Scalar()
+        {
+            fixed (float* input = _input, output = _output)
+            {
+                for (int i = 0; i < Size; i++)
+                {
+                    output[i] = (float)Math.Log(input[i]);
+                }
+            }
+        }
+
+        [Benchmark]
+        public unsafe void Vector128Logarithm()
+        {
+            // Algorithm based on Arm Optimized-Routines.
+            // https://github.com/ARM-software/optimized-routines/blob/v25.07/math/aarch64/advsimd/logf.c
+            fixed (float* input = _input, output = _output, d = _data)
+            {
+                int i = 0;
+                Vector128<uint> offVec = Vector128.Create(0x3f2aaaabu);
+
+                for (; i <= Size - 4; i += 4)
+                {
+                    Vector128<float> x = AdvSimd.LoadVector128(input + i);
+                    Vector128<uint> u_off = AdvSimd.Subtract(x.AsUInt32(), offVec);
+
+                    Vector64<ushort> cmp = AdvSimd.CompareGreaterThanOrEqual(
+                        AdvSimd.SubtractHighNarrowingLower(u_off, Vector128.Create(0xc1555555u)), // u_off - (0x00800000 - 0x3f2aaaab)
+                        Vector64.Create((ushort)0x7f00)
+                    );
+
+                    // x = 2^n * (1+r), where 2/3 < 1+r < 4/3.
+                    Vector128<float> n = AdvSimd.ConvertToSingle(
+                        AdvSimd.ShiftRightArithmetic(u_off.AsInt32(), 23)
+                    );
+
+                    Vector128<uint> u = AdvSimd.And(u_off, Vector128.Create(0x007fffffu));
+                    u = AdvSimd.Add(u, offVec);
+
+                    Vector128<float> r = AdvSimd.Subtract(u.AsSingle(), Vector128.Create(1.0f));
+                    // y = log(1+r) + n*ln2.
+                    Vector128<float> r2 = AdvSimd.Multiply(r, r);
+
+                    // n*ln2 + r + r2*(P6 + r*P5 + r2*(P4 + r*P3 + r2*(P2 + r*P1 + r2*P0))).
+                    Vector128<float> p_0135 = AdvSimd.LoadVector128(&d[0]);
+                    Vector128<float> p = AdvSimd.Arm64.FusedMultiplyAddBySelectedScalar(Vector128.Create(d[4]), r, p_0135, 1);
+                    Vector128<float> q = AdvSimd.Arm64.FusedMultiplyAddBySelectedScalar(Vector128.Create(d[5]), r, p_0135, 2);
+                    Vector128<float> y = AdvSimd.Arm64.FusedMultiplyAddBySelectedScalar(Vector128.Create(d[6]), r, p_0135, 3);
+                    p = AdvSimd.Arm64.FusedMultiplyAddBySelectedScalar(p, r2, p_0135, 0);
+
+                    q = AdvSimd.FusedMultiplyAdd(q, r2, p);
+                    y = AdvSimd.FusedMultiplyAdd(y, r2, q);
+                    p = AdvSimd.FusedMultiplyAdd(r, n, Vector128.Create(d[7]));
+
+                    Vector128<float> outVec = AdvSimd.FusedMultiplyAdd(p, r2, y);
+
+                    // Handle special case.
+                    if (cmp.AsUInt64().ToScalar() != 0)
+                    {
+                        // Restore input x.
+                        x = AdvSimd.Add(u_off, offVec).AsSingle();
+                        // Widen cmp to 32-bit lanes.
+                        Vector128<uint> pCmp = AdvSimd.ZeroExtendWideningLower(cmp);
+                        // Use scalar for lanes that are special cases.
+                        outVec = Vector128.Create(
+                            pCmp[0] != 0 ? (float)Math.Log(x[0]) : outVec[0],
+                            pCmp[1] != 0 ? (float)Math.Log(x[1]) : outVec[1],
+                            pCmp[2] != 0 ? (float)Math.Log(x[2]) : outVec[2],
+                            pCmp[3] != 0 ? (float)Math.Log(x[3]) : outVec[3]
+                        );
+                    }
+
+                    AdvSimd.Store(output + i, outVec);
+                }
+                // Handle tail.
+                for (; i < Size; i++)
+                {
+                    output[i] = (float)Math.Log(input[i]);
+                }
+            }
+        }
+
+        [Benchmark]
+        public unsafe void SveLogarithm()
+        {
+            // Algorithm based on Arm Optimized-Routines.
+            // https://github.com/ARM-software/optimized-routines/blob/v25.07/math/aarch64/sve/logf.c
+            fixed (float* input = _input, output = _output, d = _data)
+            {
+                int i = 0;
+                int cntw = (int)Sve.Count32BitElements();
+
+                Vector<uint> offVec = new Vector<uint>(0x3f2aaaab);
+
+                Vector<uint> pTrue = Sve.CreateTrueMaskUInt32();
+                Vector<float> pTruef = Sve.CreateTrueMaskSingle();
+                Vector<uint> pLoop = Sve.CreateWhileLessThanMask32Bit(0, Size);
+                while (Sve.TestFirstTrue(pTrue, pLoop))
+                {
+                    Vector<float> x = (Vector<float>)Sve.LoadVector(pLoop, (uint*)(input + i));
+                    Vector<uint> u_off = Sve.Subtract((Vector<uint>)x, offVec);
+
+                    // Check for extreme values outside of 0x00800000 and 0x00ffffff.
+                    Vector<uint> cmp = Sve.CompareGreaterThanOrEqual(
+                        Sve.Subtract(u_off, new Vector<uint>(0xc1555555u)), // u_off - (0x00800000 - 0x3f2aaaab)
+                        new Vector<uint>(0x7f000000)
+                    );
+
+                    // x = 2^n * (1+r), where 2/3 < 1+r < 4/3.
+                    Vector<float> n = Sve.ConvertToSingle(
+                        Sve.ShiftRightArithmetic((Vector<int>)u_off, new Vector<uint>(23))
+                    );
+
+                    Vector<uint> u = Sve.And(u_off, new Vector<uint>(0x007fffff));
+                    u = Sve.Add(u, offVec);
+
+                    Vector<float> r = Sve.Subtract((Vector<float>)u, new Vector<float>(1.0f));
+
+                    // y = log(1+r) + n*ln2.
+                    Vector<float> r2 = Sve.Multiply(r, r);
+
+                    // n*ln2 + r + r2*(P6 + r*P5 + r2*(P4 + r*P3 + r2*(P2 + r*P1 + r2*P0))).
+                    Vector<float> p_0135 = Sve.LoadVector(pTruef, &d[0]);
+                    Vector<float> p = Sve.FusedMultiplyAddBySelectedScalar(new Vector<float>(d[4]), r, p_0135, 1);
+                    Vector<float> q = Sve.FusedMultiplyAddBySelectedScalar(new Vector<float>(d[5]), r, p_0135, 2);
+                    Vector<float> y = Sve.FusedMultiplyAddBySelectedScalar(new Vector<float>(d[6]), r, p_0135, 3);
+                    p = Sve.FusedMultiplyAddBySelectedScalar(p, r2, p_0135, 0);
+
+                    q = Sve.FusedMultiplyAdd(q, r2, p);
+                    y = Sve.FusedMultiplyAdd(y, r2, q);
+                    p = Sve.FusedMultiplyAdd(r, n, new Vector<float>(d[7]));
+
+                    Vector<float> outVec = Sve.FusedMultiplyAdd(p, r2, y);
+                    // Handle special case.
+                    if (Sve.TestAnyTrue(pTrue, cmp))
+                    {
+                        // Restore input x.
+                        x = (Vector<float>)Sve.Add(u_off, offVec);
+                        // Get the first extreme value.
+                        Vector<uint> pElem = Sve.CreateMaskForFirstActiveElement(
+                            cmp, Sve.CreateFalseMaskUInt32()
+                        );
+                        while (Sve.TestAnyTrue(cmp, pElem))
+                        {
+                            float elem = Sve.ConditionalExtractLastActiveElement(
+                                (Vector<float>)pElem, 0, x
+                            );
+                            // Fallback to scalar for extreme values.
+                            elem = (float)Math.Log(elem);
+                            Vector<float> y2 = new Vector<float>(elem);
+                            // Replace value back to outVec.
+                            outVec = Sve.ConditionalSelect((Vector<float>)pElem, y2, outVec);
+                            // Get next extreme value.
+                            pElem = Sve.CreateMaskForNextActiveElement(cmp, pElem);
+                        }
+                    }
+
+                    Sve.StoreAndZip(pLoop, (uint*)output + i, (Vector<uint>)outVec);
+
+                    // Handle loop.
+                    i += cntw;
+                    pLoop = Sve.CreateWhileLessThanMask32Bit(i, Size);
+                }
+            }
+        }
+
+    }
+}

--- a/src/benchmarks/micro/sve/MultiplyAdd.cs
+++ b/src/benchmarks/micro/sve/MultiplyAdd.cs
@@ -1,0 +1,179 @@
+using System;
+using System.Diagnostics;
+using System.Numerics;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Extensions;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Filters;
+using MicroBenchmarks;
+
+namespace SveBenchmarks
+{
+    [BenchmarkCategory(Categories.Runtime)]
+    [OperatingSystemsArchitectureFilter(allowed: true, System.Runtime.InteropServices.Architecture.Arm64)]
+    [Config(typeof(Config))]
+    public class MultiplyAdd
+    {
+        private class Config : ManualConfig
+        {
+            public Config()
+            {
+                AddFilter(new SimpleFilter(_ => Sve.IsSupported));
+            }
+        }
+
+        [Params(15, 127, 527, 10015)]
+        public int Size;
+
+        private int[] _source1;
+        private int[] _source2;
+        private int _result;
+
+        [GlobalSetup]
+        public virtual void Setup()
+        {
+            _source1 = ValuesGenerator.Array<int>(Size);
+            _source2 = ValuesGenerator.Array<int>(Size);
+        }
+
+        [GlobalCleanup]
+        public virtual void Verify()
+        {
+            int current = _result;
+            Setup();
+            Scalar();
+            int scalar = _result;
+            // Check that the result is the same as the scalar result.
+            Debug.Assert(current == scalar);
+        }
+
+        [Benchmark]
+        public unsafe void Scalar()
+        {
+            fixed (int* a = _source1, b = _source2)
+            {
+                int res = 0;
+                for (int i = 0; i < Size; i++)
+                {
+                    res += (int)(a[i] * b[i]);
+                }
+                _result = res;
+            }
+        }
+
+        [Benchmark]
+        public unsafe void Vector128MultiplyAdd()
+        {
+            fixed (int* a = _source1, b = _source2)
+            {
+                int incr = sizeof(Vector128<int>) / sizeof(int);
+                int i = 0;
+
+                // The length of the tail is Size modulo 4 * element count.
+                int lmt = Size - (Size % (incr << 2));
+
+                Vector128<int> res1 = Vector128<int>.Zero;
+                Vector128<int> res2 = Vector128<int>.Zero;
+                Vector128<int> res3 = Vector128<int>.Zero;
+                Vector128<int> res4 = Vector128<int>.Zero;
+
+                for (; i < lmt; i += incr << 2)
+                {
+                    // Unroll loop by 4.
+                    Vector128<int> aVec1 = AdvSimd.LoadVector128(a + i);
+                    Vector128<int> bVec1 = AdvSimd.LoadVector128(b + i);
+                    Vector128<int> aVec2 = AdvSimd.LoadVector128(a + i + incr);
+                    Vector128<int> bVec2 = AdvSimd.LoadVector128(b + i + incr);
+                    Vector128<int> aVec3 = AdvSimd.LoadVector128(a + i + incr * 2);
+                    Vector128<int> bVec3 = AdvSimd.LoadVector128(b + i + incr * 2);
+                    Vector128<int> aVec4 = AdvSimd.LoadVector128(a + i + incr * 3);
+                    Vector128<int> bVec4 = AdvSimd.LoadVector128(b + i + incr * 3);
+
+                    // Calculate 4 vectors at a time.
+                    res1 = AdvSimd.MultiplyAdd(res1, aVec1, bVec1);
+                    res2 = AdvSimd.MultiplyAdd(res2, aVec2, bVec2);
+                    res3 = AdvSimd.MultiplyAdd(res3, aVec3, bVec3);
+                    res4 = AdvSimd.MultiplyAdd(res4, aVec4, bVec4);
+                }
+
+                // Sum all the results between the 4 vectors.
+                res1 = Vector128.Add(res1, res2);
+                res3 = Vector128.Add(res3, res4);
+                res1 = Vector128.Add(res1, res3);
+                int res = AdvSimd.Arm64.AddAcross(res1).ToScalar();
+
+                // Process any remaining elements.
+                for (; i < Size; i++)
+                {
+                    res += (int)(a[i] * b[i]);
+                }
+                _result = res;
+            }
+        }
+
+        [Benchmark]
+        public unsafe void SveMultiplyAdd()
+        {
+            fixed (int* a = _source1, b = _source2)
+            {
+                int i = 0;
+                int cntw = (int)Sve.Count32BitElements();
+
+                // The length of the tail is Size modulo 4 * element count.
+                int lmt = (int)Size - (Size % (cntw << 2));
+
+                Vector<int> res1 = Vector<int>.Zero;
+                Vector<int> res2 = Vector<int>.Zero;
+                Vector<int> res3 = Vector<int>.Zero;
+                Vector<int> res4 = Vector<int>.Zero;
+                Vector<int> pTrue = Sve.CreateTrueMaskInt32();
+
+                while (i < lmt)
+                {
+                    // Unroll loop by 4.
+                    Vector<int> aVec1 = Sve.LoadVector(pTrue, a + i);
+                    Vector<int> bVec1 = Sve.LoadVector(pTrue, b + i);
+                    Vector<int> aVec2 = Sve.LoadVector(pTrue, a + i + cntw);
+                    Vector<int> bVec2 = Sve.LoadVector(pTrue, b + i + cntw);
+                    Vector<int> aVec3 = Sve.LoadVector(pTrue, a + i + cntw * 2);
+                    Vector<int> bVec3 = Sve.LoadVector(pTrue, b + i + cntw * 2);
+                    Vector<int> aVec4 = Sve.LoadVector(pTrue, a + i + cntw * 3);
+                    Vector<int> bVec4 = Sve.LoadVector(pTrue, b + i + cntw * 3);
+
+                    // Calculate 4 vectors at a time.
+                    res1 = Sve.MultiplyAdd(res1, aVec1, bVec1);
+                    res2 = Sve.MultiplyAdd(res2, aVec2, bVec2);
+                    res3 = Sve.MultiplyAdd(res3, aVec3, bVec3);
+                    res4 = Sve.MultiplyAdd(res4, aVec4, bVec4);
+
+                    // Increment counter by 4 times the element count.
+                    i = Sve.SaturatingIncrementBy32BitElementCount(i, 4);
+                }
+
+                // Handle remaining elements using predicates.
+                lmt = Size;
+                Vector<int> pLoop = (Vector<int>)Sve.CreateWhileLessThanMask32Bit(i, lmt);
+                while (Sve.TestAnyTrue(pTrue, pLoop))
+                {
+                    Vector<int> aVec = Sve.LoadVector(pLoop, a + i);
+                    Vector<int> bVec = Sve.LoadVector(pLoop, b + i);
+
+                    // Apply pLoop mask on the result.
+                    res1 = Sve.ConditionalSelect(pLoop, Sve.MultiplyAdd(res1, aVec, bVec), res1);
+
+                    // Increment by a vector length.
+                    i += cntw;
+                    pLoop = (Vector<int>)Sve.CreateWhileLessThanMask32Bit(i, lmt);
+                }
+
+                // Sum up all elements in the 4 result vectors.
+                res1 = Sve.Add(res1, res2);
+                res3 = Sve.Add(res3, res4);
+                _result = (int)Sve.AddAcross(Sve.Add(res1, res3)).ToScalar();
+            }
+        }
+
+    }
+}

--- a/src/benchmarks/micro/sve/SquareRoot.cs
+++ b/src/benchmarks/micro/sve/SquareRoot.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Diagnostics;
+using System.Numerics;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.Arm;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Extensions;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Filters;
+using MicroBenchmarks;
+
+namespace SveBenchmarks
+{
+    [BenchmarkCategory(Categories.Runtime)]
+    [OperatingSystemsArchitectureFilter(allowed: true, System.Runtime.InteropServices.Architecture.Arm64)]
+    [Config(typeof(Config))]
+    public class SquareRoot
+    {
+        private class Config : ManualConfig
+        {
+            public Config()
+            {
+                AddFilter(new SimpleFilter(_ => Sve.IsSupported));
+            }
+        }
+
+        [Params(15, 127, 527, 10015)]
+        public int Size;
+
+        private float[] _input;
+        private float[] _output;
+
+        [GlobalSetup]
+        public virtual void Setup()
+        {
+            _input = ValuesGenerator.Array<float>(Size);
+            _output = new float[Size];
+        }
+
+        [GlobalCleanup]
+        public virtual void Verify()
+        {
+            float[] current = (float[])_output.Clone();
+            Setup();
+            Scalar();
+            float[] scalar = (float[])_output.Clone();
+            // Check that the result is the same as scalar.
+            for (int i = 0; i < Size; i++)
+            {
+                Debug.Assert(current[i] == scalar[i]);
+            }
+        }
+
+        [Benchmark]
+        public unsafe void Scalar()
+        {
+            fixed (float* input = _input, output = _output)
+            {
+                for (int i = 0; i < Size; i++)
+                {
+                    output[i] = (float)Math.Sqrt(input[i]);
+                }
+            }
+        }
+
+        [Benchmark]
+        public unsafe void Vector128SquareRoot()
+        {
+            fixed (float* input = _input, output = _output)
+            {
+                int i = 0;
+                for (; i <= Size - 4; i += 4)
+                {
+                    Vector128<float> inVec = AdvSimd.LoadVector128(input + i);
+                    Vector128<float> outVec = AdvSimd.Arm64.Sqrt(inVec);
+                    AdvSimd.Store(output + i, outVec);
+                }
+                // Handle tail.
+                for (; i < Size; i++)
+                {
+                    output[i] = (float)Math.Sqrt(input[i]);
+                }
+            }
+        }
+
+        [Benchmark]
+        public unsafe void SveSquareRoot()
+        {
+            fixed (float* input = _input, output = _output)
+            {
+                int i = 0;
+                int cntw = (int)Sve.Count32BitElements();
+
+                // We use Vector<uint> for predicates since there are no Vector<float>
+                // overloads for TestFirstTrue and CreateWhileLessThanMask etc.
+                Vector<uint> pTrue = Sve.CreateTrueMaskUInt32();
+                Vector<uint> pLoop = Sve.CreateWhileLessThanMask32Bit(0, Size);
+                while (Sve.TestFirstTrue(pTrue, pLoop))
+                {
+                    // Since pLoop is a Vector<uint> predicate, we load the input as uint array,
+                    // then cast it back to Vector<float>.
+                    // This is preferable to casting pLoop to Vector<float>, which would cause
+                    // an unnecessary conversion from predicate to vector in the codegen.
+                    Vector<float> inVec = (Vector<float>)Sve.LoadVector(pLoop, (uint*)(input + i));
+                    Vector<float> outVec = Sve.Sqrt(inVec);
+                    Sve.StoreAndZip(pLoop, (uint*)output + i, (Vector<uint>)outVec);
+
+                    // Handle loop.
+                    i += cntw;
+                    pLoop = Sve.CreateWhileLessThanMask32Bit(i, Size);
+                }
+            }
+        }
+
+        [Benchmark]
+        public unsafe void SveTail()
+        {
+            fixed (float* input = _input, output = _output)
+            {
+                int i = 0;
+                int cntw = (int)Sve.Count32BitElements();
+
+                Vector<float> pTrue = Sve.CreateTrueMaskSingle();
+                for (; i <= Size - cntw; i += cntw)
+                {
+                    Vector<float> inVec = Sve.LoadVector(pTrue, input + i);
+                    Vector<float> outVec = Sve.Sqrt(inVec);
+                    Sve.StoreAndZip(pTrue, output + i, outVec);
+                }
+                // Handle tail.
+                for (; i < Size; i++)
+                {
+                    output[i] = (float)Math.Sqrt(input[i]);
+                }
+            }
+        }
+
+    }
+}

--- a/src/benchmarks/real-world/PowerShell.Benchmarks/PowerShell.Benchmarks.csproj
+++ b/src/benchmarks/real-world/PowerShell.Benchmarks/PowerShell.Benchmarks.csproj
@@ -7,6 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <StartArguments>--filter *</StartArguments>
+    <LangVersion>preview</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/benchmarks/real-world/Roslyn/CompilerBenchmarks.csproj
+++ b/src/benchmarks/real-world/Roslyn/CompilerBenchmarks.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/benchmarks/real-world/Roslyn/Helpers.cs
+++ b/src/benchmarks/real-world/Roslyn/Helpers.cs
@@ -59,7 +59,7 @@ namespace CompilerBenchmarks
                 LanguageNames.CSharp,
                 new List<DiagnosticInfo>(),
                 MessageProvider.Instance,
-                new DefaultAnalyzerAssemblyLoader(),
+                new AnalyzerAssemblyLoader(),
                 cmdLineArgs.CompilationOptions,
                 skipAnalyzers: false,
                 out var analyzers,

--- a/src/scenarios/bdnandroid/test.py
+++ b/src/scenarios/bdnandroid/test.py
@@ -9,8 +9,8 @@ from shared.versionmanager import versions_read_json_file_save_env
 EXENAME = 'BDNAndroidTest'
 
 if __name__ == "__main__":
-    if os.path.exists(rf".\{PUBDIR}\versions.json"):
-        versions_read_json_file_save_env(rf".\{PUBDIR}\versions.json")
+    if os.path.exists(os.path.join(".", PUBDIR, "versions.json")):
+        versions_read_json_file_save_env(os.path.join(".", PUBDIR, "versions.json"))
 
     traits = TestTraits(exename=EXENAME, 
                         guiapp='false',

--- a/src/scenarios/blazorpizza/src/BlazingPizza.Client/Shared/LoginDisplay.razor
+++ b/src/scenarios/blazorpizza/src/BlazingPizza.Client/Shared/LoginDisplay.razor
@@ -1,7 +1,4 @@
-﻿@inject NavigationManager Navigation
-@inject SignOutSessionStateManager SignOutManager
-
-<div class="user-info">
+﻿<div class="user-info">
     <AuthorizeView>
         <Authorizing>
             <text>...</text>
@@ -19,11 +16,3 @@
         </NotAuthorized>
     </AuthorizeView>
 </div>
-
-@code{
-    async Task BeginSignOut()
-    {
-        await SignOutManager.SetSignOutState();
-        Navigation.NavigateTo("authentication/logout");
-    }
-}

--- a/src/scenarios/blazorpizza/src/BlazingPizza.Client/Shared/LoginDisplay.razor.cs
+++ b/src/scenarios/blazorpizza/src/BlazingPizza.Client/Shared/LoginDisplay.razor.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
+using System.Threading.Tasks;  
+
+namespace BlazingPizza.Client.Shared;
+
+public partial class LoginDisplay
+{
+    [Inject]
+    private NavigationManager Navigation { get; set; } = default!;
+
+#if !NET11_0_OR_GREATER
+    [Inject]
+    private SignOutSessionStateManager SignOutManager { get; set; } = default!;
+#endif
+
+#if NET11_0_OR_GREATER
+    private void BeginSignOut()
+    {
+        Navigation.NavigateToLogout("authentication/logout");
+    }
+#else
+    private async Task BeginSignOut()
+    {
+        await SignOutManager.SetSignOutState();
+        Navigation.NavigateTo("authentication/logout");
+    }
+#endif
+}

--- a/src/scenarios/blazorpizzaaot/src/BlazingPizza.Client/Shared/LoginDisplay.razor
+++ b/src/scenarios/blazorpizzaaot/src/BlazingPizza.Client/Shared/LoginDisplay.razor
@@ -1,7 +1,4 @@
-﻿@inject NavigationManager Navigation
-@inject SignOutSessionStateManager SignOutManager
-
-<div class="user-info">
+﻿<div class="user-info">
     <AuthorizeView>
         <Authorizing>
             <text>...</text>
@@ -19,11 +16,3 @@
         </NotAuthorized>
     </AuthorizeView>
 </div>
-
-@code{
-    async Task BeginSignOut()
-    {
-        await SignOutManager.SetSignOutState();
-        Navigation.NavigateTo("authentication/logout");
-    }
-}

--- a/src/scenarios/blazorpizzaaot/src/BlazingPizza.Client/Shared/LoginDisplay.razor.cs
+++ b/src/scenarios/blazorpizzaaot/src/BlazingPizza.Client/Shared/LoginDisplay.razor.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
+using System.Threading.Tasks;  
+
+namespace BlazingPizza.Client.Shared;
+
+public partial class LoginDisplay
+{
+    [Inject]
+    private NavigationManager Navigation { get; set; } = default!;
+
+#if !NET11_0_OR_GREATER
+    [Inject]
+    private SignOutSessionStateManager SignOutManager { get; set; } = default!;
+#endif
+
+#if NET11_0_OR_GREATER
+    private void BeginSignOut()
+    {
+        Navigation.NavigateToLogout("authentication/logout");
+    }
+#else
+    private async Task BeginSignOut()
+    {
+        await SignOutManager.SetSignOutState();
+        Navigation.NavigateTo("authentication/logout");
+    }
+#endif
+}

--- a/src/scenarios/build-common/Blazor.Directory.Build.targets
+++ b/src/scenarios/build-common/Blazor.Directory.Build.targets
@@ -5,7 +5,7 @@
       Text="Package versions for blazor/aspnetcore not set. %24(AspNetCoreVersion)=$(AspNetCoreVersion), %24(BlazorVersion)==$(BlazorVersion), and %24(SystemNetHttpJsonVersion)=$(SystemNetHttpJsonVersion). TFM: $(TargetFramework)" />
 
     <Warning
-      Condition="$(TargetFrameworks.Contains('net10.0')) or ($(TargetFrameworkVersion) != '' and $([MSBuild]::VersionGreaterThan('$(TargetFrameworkVersion)', '9.0')))"
+      Condition="$(TargetFrameworks.Contains('net12.0')) or ($(TargetFrameworkVersion) != '' and $([MSBuild]::VersionGreaterThan('$(TargetFrameworkVersion)', '11.0')))"
       Text="Package versions being used for blazor project might need to be updated for a new tfm. Current values: %24(AspNetCoreVersion)=$(AspNetCoreVersion), %24(BlazorVersion)==$(BlazorVersion), and %24(SystemNetHttpJsonVersion)=$(SystemNetHttpJsonVersion). TFM: $(TargetFramework)" />
   </Target>
 

--- a/src/scenarios/build-common/Blazor.PackageVersions.props
+++ b/src/scenarios/build-common/Blazor.PackageVersions.props
@@ -1,4 +1,9 @@
 <Project>
+    <PropertyGroup Condition="$(TargetFrameworks.Contains('net11.0')) or ($(TargetFrameworkVersion) != '' and $([MSBuild]::VersionEquals('$(TargetFrameworkVersion)', '11.0')))">
+        <AspNetCoreVersion>11.0.0-*</AspNetCoreVersion>
+        <BlazorVersion>11.0.0-*</BlazorVersion>
+        <SystemNetHttpJsonVersion>11.0.0-*</SystemNetHttpJsonVersion>
+    </PropertyGroup>
     <PropertyGroup Condition="$(TargetFrameworks.Contains('net10.0')) or ($(TargetFrameworkVersion) != '' and $([MSBuild]::VersionEquals('$(TargetFrameworkVersion)', '10.0')))">
         <AspNetCoreVersion>10.0.0-*</AspNetCoreVersion>
         <BlazorVersion>10.0.0-*</BlazorVersion>
@@ -26,26 +31,4 @@
         <BlazorVersion Condition="'$(BlazorVersion)' == ''">6.0.0-preview*</BlazorVersion>
         <SystemNetHttpJsonVersion Condition="'$(SystemNetHttpJsonVersion)' == ''">6.0.0-preview*</SystemNetHttpJsonVersion>
     </PropertyGroup>
-
-      <!-- Workaround: Explicit Microsoft.Extensions pre-release versions for net10.0.
-       The WebAssembly SDK depends on Microsoft.Extensions packages with version >=10.0.0.
-       Only pre-release (rtm/rc) builds are presently available in internal feeds; since
-       NuGet treats pre-release < stable, transitive resolution fails. We force a floating
-       pre-release selection via explicit PackageReferences conditioned on net10.0. -->
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))">
-    <ExtensionsVersion>10.0.0-*</ExtensionsVersion>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <!-- Explicit extensions packages (conditional) -->
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
-    <PackageReference Include="Microsoft.Extensions.Primitives" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
-  </ItemGroup>
 </Project>

--- a/src/scenarios/build-common/Blazor.PackageVersions.props
+++ b/src/scenarios/build-common/Blazor.PackageVersions.props
@@ -26,4 +26,26 @@
         <BlazorVersion Condition="'$(BlazorVersion)' == ''">6.0.0-preview*</BlazorVersion>
         <SystemNetHttpJsonVersion Condition="'$(SystemNetHttpJsonVersion)' == ''">6.0.0-preview*</SystemNetHttpJsonVersion>
     </PropertyGroup>
+
+      <!-- Workaround: Explicit Microsoft.Extensions pre-release versions for net10.0.
+       The WebAssembly SDK depends on Microsoft.Extensions packages with version >=10.0.0.
+       Only pre-release (rtm/rc) builds are presently available in internal feeds; since
+       NuGet treats pre-release < stable, transitive resolution fails. We force a floating
+       pre-release selection via explicit PackageReferences conditioned on net10.0. -->
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))">
+    <ExtensionsVersion>10.0.0-*</ExtensionsVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Explicit extensions packages (conditional) -->
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
+    <PackageReference Include="Microsoft.Extensions.Primitives" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics" Version="$(ExtensionsVersion)" Condition="'$(TargetFramework)' == 'net10.0' or $(TargetFrameworks.Contains('net10.0'))" />
+  </ItemGroup>
 </Project>

--- a/src/scenarios/emptyconsolenativeaot/pre.py
+++ b/src/scenarios/emptyconsolenativeaot/pre.py
@@ -17,7 +17,7 @@ precommands.new(template='console',
 args = ['/p:PublishAot=true', '/p:StripSymbols=true', '/p:IlcGenerateMstatFile=true']
 if not iswin():
     args.extend(['/p:ObjCopyName=objcopy'])
-precommands.add_onmain_logging("Program.cs", "// See https://aka.ms/new-console-template for more information")
+precommands.add_onmain_logging("Program.cs", "Console.WriteLine")
 precommands.execute(args)
 
 src = os.path.join(const.APPDIR, 'obj', precommands.configuration, precommands.framework, precommands.runtime_identifier, 'native', f'{EXENAME}.mstat')

--- a/src/scenarios/emptyconsoletemplate/pre.py
+++ b/src/scenarios/emptyconsoletemplate/pre.py
@@ -14,5 +14,5 @@ precommands.new(template='console',
                 bin_dir=const.BINDIR,
                 exename=EXENAME,
                 working_directory=sys.path[0])
-precommands.add_onmain_logging("Program.cs", "// See https://aka.ms/new-console-template for more information")
+precommands.add_onmain_logging("Program.cs", "Console.WriteLine")
 precommands.execute()

--- a/src/scenarios/mauiandroid/pre.py
+++ b/src/scenarios/mauiandroid/pre.py
@@ -1,6 +1,7 @@
 '''
 pre-command
 '''
+import os
 import shutil
 import sys
 from performance.logger import setup_loggers, getLogger
@@ -39,7 +40,10 @@ if precommands.output:
     output_dir = precommands.output
 remove_aab_files(output_dir)
 
-# Extract the versions of used SDKs from the linked folder DLLs
-version_dict = get_sdk_versions(rf".\{const.APPDIR}\obj\Release\{precommands.framework}\android-arm64\linked")
-versions_write_json(version_dict, rf"{output_dir}\versions.json")
-print(f"Versions: {version_dict} from location " + rf".\{const.APPDIR}\obj\Release\{precommands.framework}\android-arm64\linked")
+# Extract the versions of used SDKs from the linked folder DLLs (Release) or assets folder (Debug)
+dll_folder = os.path.join(".", const.APPDIR, "obj", precommands.configuration, precommands.framework, "android-arm64", "linked")
+if not os.path.isdir(dll_folder):
+    dll_folder = os.path.join(".", const.APPDIR, "obj", precommands.configuration, precommands.framework, "android-arm64", "android", "assets", "arm64-v8a")
+version_dict = get_sdk_versions(dll_folder)
+versions_write_json(version_dict, os.path.join(output_dir, "versions.json"))
+print(f"Versions: {version_dict} from location {dll_folder}")

--- a/src/scenarios/mauiandroid/pre.py
+++ b/src/scenarios/mauiandroid/pre.py
@@ -5,7 +5,7 @@ import shutil
 import sys
 from performance.logger import setup_loggers, getLogger
 from shared import const
-from shared.mauisharedpython import remove_aab_files, install_latest_maui
+from shared.mauisharedpython import remove_aab_files, install_latest_maui, MauiNuGetConfigContext
 from shared.precommands import PreCommands
 from shared.versionmanager import versions_write_json, get_sdk_versions
 from test import EXENAME
@@ -19,16 +19,20 @@ precommands = PreCommands()
 install_latest_maui(precommands)
 precommands.print_dotnet_info()
 
-# Setup the Maui folder
-precommands.new(template='maui',
-                output_dir=const.APPDIR,
-                bin_dir=const.BINDIR,
-                exename=EXENAME,
-                working_directory=sys.path[0],
-                no_restore=False)
-
-# Build the APK
-precommands.execute([])
+# Use context manager to temporarily merge MAUI's NuGet feeds into repo config
+# This ensures both dotnet new and dotnet build/publish have access to MAUI packages
+with MauiNuGetConfigContext(precommands.framework):
+    # Setup the Maui folder - will use merged NuGet.config with MAUI feeds
+    precommands.new(template='maui',
+                    output_dir=const.APPDIR,
+                    bin_dir=const.BINDIR,
+                    exename=EXENAME,
+                    working_directory=sys.path[0],
+                    no_restore=False)
+    
+    # Build the APK - will also use merged NuGet.config
+    precommands.execute([])
+# NuGet.config is automatically restored after this block
 
 # Remove the aab files as we don't need them, this saves space
 output_dir = const.PUBDIR

--- a/src/scenarios/mauiandroid/pre.py
+++ b/src/scenarios/mauiandroid/pre.py
@@ -16,12 +16,11 @@ logger.info("Starting pre-command for MAUI Android template app (dotnet new maui
 
 precommands = PreCommands()
 
-install_latest_maui(precommands)
-precommands.print_dotnet_info()
-
 # Use context manager to temporarily merge MAUI's NuGet feeds into repo config
-# This ensures both dotnet new and dotnet build/publish have access to MAUI packages
+# This ensures dotnet package search, dotnet new, and dotnet build/publish have access to MAUI packages
 with MauiNuGetConfigContext(precommands.framework):
+    install_latest_maui(precommands)
+    precommands.print_dotnet_info()
     # Setup the Maui folder - will use merged NuGet.config with MAUI feeds
     precommands.new(template='maui',
                     output_dir=const.APPDIR,
@@ -32,7 +31,7 @@ with MauiNuGetConfigContext(precommands.framework):
     
     # Build the APK - will also use merged NuGet.config
     precommands.execute([])
-# NuGet.config is automatically restored after this block
+    # NuGet.config is automatically restored after this block
 
 # Remove the aab files as we don't need them, this saves space
 output_dir = const.PUBDIR

--- a/src/scenarios/mauiandroid/test.py
+++ b/src/scenarios/mauiandroid/test.py
@@ -1,6 +1,7 @@
 '''
 Mobile Maui App
 '''
+import os
 from shared.const import PUBDIR
 from shared.runner import TestTraits, Runner
 from shared.versionmanager import versions_read_json_file_save_env
@@ -8,7 +9,7 @@ from shared.versionmanager import versions_read_json_file_save_env
 EXENAME = 'MauiAndroidDefault'
 
 if __name__ == "__main__":    
-    versions_read_json_file_save_env(rf".\{PUBDIR}\versions.json")
+    versions_read_json_file_save_env(os.path.join(".", PUBDIR, "versions.json"))
 
     traits = TestTraits(exename=EXENAME, 
                         guiapp='false',

--- a/src/scenarios/mauiblazorandroid/pre.py
+++ b/src/scenarios/mauiblazorandroid/pre.py
@@ -1,6 +1,7 @@
 '''
 pre-command
 '''
+import os
 import shutil
 import sys
 from performance.logger import setup_loggers, getLogger
@@ -69,7 +70,10 @@ if precommands.output:
     output_dir = precommands.output
 remove_aab_files(output_dir)
 
-# Extract the versions of used SDKs from the linked folder DLLs
-version_dict = get_sdk_versions(rf".\{const.APPDIR}\obj\Release\{precommands.framework}\android-arm64\linked")
-versions_write_json(version_dict, rf"{output_dir}\versions.json")
-print(f"Versions: {version_dict} from location " + rf".\{const.APPDIR}\obj\Release\{precommands.framework}\android-arm64\linked")
+# Extract the versions of used SDKs from the linked folder DLLs (Release) or assets folder (Debug)
+dll_folder = os.path.join(".", const.APPDIR, "obj", precommands.configuration, precommands.framework, "android-arm64", "linked")
+if not os.path.isdir(dll_folder):
+    dll_folder = os.path.join(".", const.APPDIR, "obj", precommands.configuration, precommands.framework, "android-arm64", "android", "assets", "arm64-v8a")
+version_dict = get_sdk_versions(dll_folder)
+versions_write_json(version_dict, os.path.join(output_dir, "versions.json"))
+print(f"Versions: {version_dict} from location {dll_folder}")

--- a/src/scenarios/mauiblazorandroid/pre.py
+++ b/src/scenarios/mauiblazorandroid/pre.py
@@ -16,12 +16,11 @@ logger.info("Starting pre-command for MAUI Blazor Android template app (dotnet n
 
 precommands = PreCommands()
 
-install_latest_maui(precommands)
-precommands.print_dotnet_info()
-
 # Use context manager to temporarily merge MAUI's NuGet feeds into repo config
-# This ensures both dotnet new and dotnet build/publish have access to MAUI packages
+# This ensures dotnet package search, dotnet new, and dotnet build/publish have access to MAUI packages
 with MauiNuGetConfigContext(precommands.framework):
+    install_latest_maui(precommands)
+    precommands.print_dotnet_info()
     # Setup the Maui folder - will use merged NuGet.config with MAUI feeds
     precommands.new(template='maui-blazor',
                     output_dir=const.APPDIR,
@@ -63,7 +62,7 @@ with MauiNuGetConfigContext(precommands.framework):
     
     # Build the APK - will use merged NuGet.config
     precommands.execute([])
-# NuGet.config is automatically restored after this block
+    # NuGet.config is automatically restored after this block
 
 output_dir = const.PUBDIR
 if precommands.output:

--- a/src/scenarios/mauiblazorandroid/pre.py
+++ b/src/scenarios/mauiblazorandroid/pre.py
@@ -5,7 +5,7 @@ import shutil
 import sys
 from performance.logger import setup_loggers, getLogger
 from shared import const
-from shared.mauisharedpython import remove_aab_files, install_latest_maui
+from shared.mauisharedpython import remove_aab_files, install_latest_maui, MauiNuGetConfigContext
 from shared.precommands import PreCommands
 from shared.versionmanager import versions_write_json, get_sdk_versions
 from test import EXENAME
@@ -19,17 +19,20 @@ precommands = PreCommands()
 install_latest_maui(precommands)
 precommands.print_dotnet_info()
 
-# Setup the Maui folder
-precommands.new(template='maui-blazor',
-                output_dir=const.APPDIR,
-                bin_dir=const.BINDIR,
-                exename=EXENAME,
-                working_directory=sys.path[0],
-                no_restore=False)
-
-# Update the home.razor file with the code
-with open(f"{const.APPDIR}/Components/Pages/Home.razor", "a") as homeRazorFile:
-    homeRazorFile.write(
+# Use context manager to temporarily merge MAUI's NuGet feeds into repo config
+# This ensures both dotnet new and dotnet build/publish have access to MAUI packages
+with MauiNuGetConfigContext(precommands.framework):
+    # Setup the Maui folder - will use merged NuGet.config with MAUI feeds
+    precommands.new(template='maui-blazor',
+                    output_dir=const.APPDIR,
+                    bin_dir=const.BINDIR,
+                    exename=EXENAME,
+                    working_directory=sys.path[0],
+                    no_restore=False)
+    
+    # Update the home.razor file with the code
+    with open(f"{const.APPDIR}/Components/Pages/Home.razor", "a") as homeRazorFile:
+        homeRazorFile.write(
 '''
 @code {
     protected override void OnAfterRender(bool firstRender)
@@ -42,24 +45,25 @@ with open(f"{const.APPDIR}/Components/Pages/Home.razor", "a") as homeRazorFile:
     }
 }
 ''')
+        
+    # Open the _Imports.razor file for appending
+    with open(f"{const.APPDIR}/_Imports.razor", "a") as importsFile:
+        importsFile.write("@using Android.App;")
     
-# Open the _Imports.razor file for appending
-with open(f"{const.APPDIR}/_Imports.razor", "a") as importsFile:
-    importsFile.write("@using Android.App;")
-
-# Replace line in the Android MainActivity.cs file
-with open(f"{const.APPDIR}/Platforms/Android/MainActivity.cs", "r") as mainActivityFile:
-    mainActivityFileLines = mainActivityFile.readlines()
-
-with open(f"{const.APPDIR}/Platforms/Android/MainActivity.cs", "w") as mainActivityFile:
-    for line in mainActivityFileLines:
-        if line.startswith("{"):
-            mainActivityFile.write("{\npublic static Android.Content.Context Context { get; private set; }\npublic MainActivity() { Context = this; }")
-        else:
-            mainActivityFile.write(line)
-
-# Build the APK
-precommands.execute([])
+    # Replace line in the Android MainActivity.cs file
+    with open(f"{const.APPDIR}/Platforms/Android/MainActivity.cs", "r") as mainActivityFile:
+        mainActivityFileLines = mainActivityFile.readlines()
+    
+    with open(f"{const.APPDIR}/Platforms/Android/MainActivity.cs", "w") as mainActivityFile:
+        for line in mainActivityFileLines:
+            if line.startswith("{"):
+                mainActivityFile.write("{\npublic static Android.Content.Context Context { get; private set; }\npublic MainActivity() { Context = this; }")
+            else:
+                mainActivityFile.write(line)
+    
+    # Build the APK - will use merged NuGet.config
+    precommands.execute([])
+# NuGet.config is automatically restored after this block
 
 output_dir = const.PUBDIR
 if precommands.output:

--- a/src/scenarios/mauiblazorandroid/test.py
+++ b/src/scenarios/mauiblazorandroid/test.py
@@ -1,6 +1,7 @@
 '''
 Mobile Maui App
 '''
+import os
 from shared.const import PUBDIR
 from shared.runner import TestTraits, Runner
 from shared.versionmanager import versions_read_json_file_save_env
@@ -8,7 +9,7 @@ from shared.versionmanager import versions_read_json_file_save_env
 EXENAME = 'MauiBlazorAndroidDefault'
 
 if __name__ == "__main__":
-    versions_read_json_file_save_env(rf".\{PUBDIR}\versions.json")
+    versions_read_json_file_save_env(os.path.join(".", PUBDIR, "versions.json"))
 
     traits = TestTraits(exename=EXENAME, 
                         guiapp='false',

--- a/src/scenarios/mauiblazordesktop/pre.py
+++ b/src/scenarios/mauiblazordesktop/pre.py
@@ -9,24 +9,28 @@ from performance.logger import setup_loggers, getLogger
 from shared.codefixes import insert_after
 from shared.precommands import PreCommands
 from shared import const
+from shared.mauisharedpython import install_latest_maui, MauiNuGetConfigContext
 from test import EXENAME
-import requests
 
 setup_loggers(True)
-
-NugetURL = 'https://raw.githubusercontent.com/dotnet/maui/net7.0/NuGet.config'
-NugetFile = requests.get(NugetURL)
-open('./Nuget.config', 'wb').write(NugetFile.content)
+logger = getLogger(__name__)
 
 precommands = PreCommands()
-precommands.install_workload('maui', ['--from-rollback-file', 'https://aka.ms/dotnet/maui/net7.0.json', '--configfile', './Nuget.config'])
-precommands.new(template='maui-blazor',
-                output_dir=const.APPDIR,
-                bin_dir=const.BINDIR,
-                exename=EXENAME,
-                working_directory=sys.path[0],
-                no_restore=False)
 
-shutil.copy2(os.path.join(const.SRCDIR, 'Replacement.Index.razor.cs'), os.path.join(const.APPDIR, 'Pages', 'Index.razor.cs'))
-precommands.add_startup_logging(os.path.join('Pages', 'Index.razor.cs'), "if (firstRender) {")
-precommands.execute(['/p:Platform=x64','/p:WindowsAppSDKSelfContained=True','/p:WindowsPackageType=None','/p:WinUISDKReferences=False','/p:PublishReadyToRun=true'])
+install_latest_maui(precommands)
+precommands.print_dotnet_info()
+
+# Use context manager to temporarily merge MAUI's NuGet feeds into repo config
+# This ensures both dotnet new and dotnet build/publish have access to MAUI packages
+with MauiNuGetConfigContext(precommands.framework):
+    precommands.new(template='maui-blazor',
+                    output_dir=const.APPDIR,
+                    bin_dir=const.BINDIR,
+                    exename=EXENAME,
+                    working_directory=sys.path[0],
+                    no_restore=False)
+    
+    shutil.copy2(os.path.join(const.SRCDIR, 'Replacement.Index.razor.cs'), os.path.join(const.APPDIR, 'Pages', 'Index.razor.cs'))
+    precommands.add_startup_logging(os.path.join('Pages', 'Index.razor.cs'), "if (firstRender) {")
+    precommands.execute(['/p:Platform=x64','/p:WindowsAppSDKSelfContained=True','/p:WindowsPackageType=None','/p:WinUISDKReferences=False','/p:PublishReadyToRun=true'])
+# NuGet.config is automatically restored after this block

--- a/src/scenarios/mauiblazordesktop/pre.py
+++ b/src/scenarios/mauiblazordesktop/pre.py
@@ -17,12 +17,11 @@ logger = getLogger(__name__)
 
 precommands = PreCommands()
 
-install_latest_maui(precommands)
-precommands.print_dotnet_info()
-
 # Use context manager to temporarily merge MAUI's NuGet feeds into repo config
-# This ensures both dotnet new and dotnet build/publish have access to MAUI packages
+# This ensures dotnet package search, dotnet new, and dotnet build/publish have access to MAUI packages
 with MauiNuGetConfigContext(precommands.framework):
+    install_latest_maui(precommands)
+    precommands.print_dotnet_info()
     precommands.new(template='maui-blazor',
                     output_dir=const.APPDIR,
                     bin_dir=const.BINDIR,
@@ -33,4 +32,4 @@ with MauiNuGetConfigContext(precommands.framework):
     shutil.copy2(os.path.join(const.SRCDIR, 'Replacement.Index.razor.cs'), os.path.join(const.APPDIR, 'Pages', 'Index.razor.cs'))
     precommands.add_startup_logging(os.path.join('Pages', 'Index.razor.cs'), "if (firstRender) {")
     precommands.execute(['/p:Platform=x64','/p:WindowsAppSDKSelfContained=True','/p:WindowsPackageType=None','/p:WinUISDKReferences=False','/p:PublishReadyToRun=true'])
-# NuGet.config is automatically restored after this block
+    # NuGet.config is automatically restored after this block

--- a/src/scenarios/mauiblazorios/pre.py
+++ b/src/scenarios/mauiblazorios/pre.py
@@ -44,7 +44,8 @@ with MauiNuGetConfigContext(precommands.framework):
 ''')
     
     # Build the IPA - will use merged NuGet.config
-    precommands.execute(['/p:EnableCodeSigning=false', '/p:ApplicationId=net.dot.mauiblazortesting'])
+    # TODO: Remove /p:TargetsCurrent=true once https://github.com/dotnet/performance/issues/5055 is resolved
+    precommands.execute(['/p:EnableCodeSigning=false', '/p:ApplicationId=net.dot.mauiblazortesting', '/p:TargetsCurrent=true'])
 # NuGet.config is automatically restored after this block
 
 output_dir = const.PUBDIR

--- a/src/scenarios/mauiblazorios/pre.py
+++ b/src/scenarios/mauiblazorios/pre.py
@@ -5,27 +5,32 @@ import shutil
 import sys
 from performance.logger import setup_loggers, getLogger
 from shared import const
-from shared.mauisharedpython import remove_aab_files, install_latest_maui
+from shared.mauisharedpython import remove_aab_files, install_latest_maui, MauiNuGetConfigContext
 from shared.precommands import PreCommands
 from shared.versionmanager import versions_write_json, get_sdk_versions
 from test import EXENAME
 
 setup_loggers(True)
+logger = getLogger(__name__)
+
 precommands = PreCommands()
 install_latest_maui(precommands)
 precommands.print_dotnet_info()
 
-# Setup the Maui folder
-precommands.new(template='maui-blazor',
-                output_dir=const.APPDIR,
-                bin_dir=const.BINDIR,
-                exename=EXENAME,
-                working_directory=sys.path[0],
-                no_restore=False)
-
-# Update the home.razor file with the code
-with open(f"{const.APPDIR}/Components/Pages/Home.razor", "a") as homeRazorFile:
-    homeRazorFile.write(
+# Use context manager to temporarily merge MAUI's NuGet feeds into repo config
+# This ensures both dotnet new and dotnet build/publish have access to MAUI packages
+with MauiNuGetConfigContext(precommands.framework):
+    # Setup the Maui folder - will use merged NuGet.config with MAUI feeds
+    precommands.new(template='maui-blazor',
+                    output_dir=const.APPDIR,
+                    bin_dir=const.BINDIR,
+                    exename=EXENAME,
+                    working_directory=sys.path[0],
+                    no_restore=False)
+    
+    # Update the home.razor file with the code
+    with open(f"{const.APPDIR}/Components/Pages/Home.razor", "a") as homeRazorFile:
+        homeRazorFile.write(
 '''
 @code {
     protected override void OnAfterRender(bool firstRender)
@@ -37,10 +42,10 @@ with open(f"{const.APPDIR}/Components/Pages/Home.razor", "a") as homeRazorFile:
     }
 }
 ''')
-
-# Build the IPA
-# NuGet.config file cannot be in the build directory due same cause as to https://github.com/dotnet/aspnetcore/issues/41397
-precommands.execute(['/p:EnableCodeSigning=false', '/p:ApplicationId=net.dot.mauiblazortesting'])
+    
+    # Build the IPA - will use merged NuGet.config
+    precommands.execute(['/p:EnableCodeSigning=false', '/p:ApplicationId=net.dot.mauiblazortesting'])
+# NuGet.config is automatically restored after this block
 
 output_dir = const.PUBDIR
 if precommands.output:

--- a/src/scenarios/mauiblazorios/pre.py
+++ b/src/scenarios/mauiblazorios/pre.py
@@ -53,7 +53,7 @@ if precommands.output:
 remove_aab_files(output_dir)
 
 # Extract the versions of used SDKs from the linked folder DLLs
-version_dict = get_sdk_versions(rf"./{const.APPDIR}/obj/Release/{precommands.framework}/ios-arm64/linked", False)
+version_dict = get_sdk_versions(rf"./{const.APPDIR}/obj/{precommands.configuration}/{precommands.framework}/ios-arm64/linked", False)
 versions_write_json(version_dict, rf"{output_dir}/versions.json")
-print(f"Versions: {version_dict} from location " + rf"./{const.APPDIR}/obj/Release/{precommands.framework}/ios-arm64/linked")
+print(f"Versions: {version_dict} from location " + rf"./{const.APPDIR}/obj/{precommands.configuration}/{precommands.framework}/ios-arm64/linked")
 

--- a/src/scenarios/mauiblazorios/pre.py
+++ b/src/scenarios/mauiblazorios/pre.py
@@ -44,8 +44,7 @@ with MauiNuGetConfigContext(precommands.framework):
 ''')
     
     # Build the IPA - will use merged NuGet.config
-    # TODO: Remove /p:TargetsCurrent=true once https://github.com/dotnet/performance/issues/5055 is resolved
-    precommands.execute(['/p:EnableCodeSigning=false', '/p:ApplicationId=net.dot.mauiblazortesting', '/p:TargetsCurrent=true'])
+    precommands.execute(['/p:EnableCodeSigning=false', '/p:ApplicationId=net.dot.mauiblazortesting'])
     # NuGet.config is automatically restored after this block
 
 output_dir = const.PUBDIR

--- a/src/scenarios/mauiblazorios/pre.py
+++ b/src/scenarios/mauiblazorios/pre.py
@@ -14,12 +14,12 @@ setup_loggers(True)
 logger = getLogger(__name__)
 
 precommands = PreCommands()
-install_latest_maui(precommands)
-precommands.print_dotnet_info()
 
 # Use context manager to temporarily merge MAUI's NuGet feeds into repo config
-# This ensures both dotnet new and dotnet build/publish have access to MAUI packages
+# This ensures dotnet package search, dotnet new, and dotnet build/publish have access to MAUI packages
 with MauiNuGetConfigContext(precommands.framework):
+    install_latest_maui(precommands)
+    precommands.print_dotnet_info()
     # Setup the Maui folder - will use merged NuGet.config with MAUI feeds
     precommands.new(template='maui-blazor',
                     output_dir=const.APPDIR,
@@ -46,7 +46,7 @@ with MauiNuGetConfigContext(precommands.framework):
     # Build the IPA - will use merged NuGet.config
     # TODO: Remove /p:TargetsCurrent=true once https://github.com/dotnet/performance/issues/5055 is resolved
     precommands.execute(['/p:EnableCodeSigning=false', '/p:ApplicationId=net.dot.mauiblazortesting', '/p:TargetsCurrent=true'])
-# NuGet.config is automatically restored after this block
+    # NuGet.config is automatically restored after this block
 
 output_dir = const.PUBDIR
 if precommands.output:

--- a/src/scenarios/mauiblazorios/test.py
+++ b/src/scenarios/mauiblazorios/test.py
@@ -1,6 +1,7 @@
 '''
 Mobile Maui App
 '''
+import os
 from shared.const import PUBDIR
 from shared.runner import TestTraits, Runner
 from shared.versionmanager import versions_read_json_file_save_env
@@ -8,7 +9,7 @@ from shared.versionmanager import versions_read_json_file_save_env
 EXENAME = 'MauiBlazoriOSDefault'
 
 if __name__ == "__main__":
-    versions_read_json_file_save_env(rf"./{PUBDIR}/versions.json")
+    versions_read_json_file_save_env(os.path.join(".", PUBDIR, "versions.json"))
 
     traits = TestTraits(exename=EXENAME, 
                         guiapp='false',

--- a/src/scenarios/mauidesktop/pre.py
+++ b/src/scenarios/mauidesktop/pre.py
@@ -16,12 +16,11 @@ logger = getLogger(__name__)
 
 precommands = PreCommands()
 
-install_latest_maui(precommands)
-precommands.print_dotnet_info()
-
 # Use context manager to temporarily merge MAUI's NuGet feeds into repo config
-# This ensures both dotnet new and dotnet build/publish have access to MAUI packages
+# This ensures dotnet package search, dotnet new, and dotnet build/publish have access to MAUI packages
 with MauiNuGetConfigContext(precommands.framework):
+    install_latest_maui(precommands)
+    precommands.print_dotnet_info()
     precommands.new(template='maui',
                     output_dir=const.APPDIR,
                     bin_dir=const.BINDIR,
@@ -30,4 +29,4 @@ with MauiNuGetConfigContext(precommands.framework):
                     no_restore=False)
     
     precommands.execute(['/p:Platform=x64','/p:WindowsAppSDKSelfContained=True','/p:WindowsPackageType=None','/p:WinUISDKReferences=False','/p:PublishReadyToRun=true'])
-# NuGet.config is automatically restored after this block
+    # NuGet.config is automatically restored after this block

--- a/src/scenarios/mauiios/pre.py
+++ b/src/scenarios/mauiios/pre.py
@@ -29,8 +29,7 @@ with MauiNuGetConfigContext(precommands.framework):
                     no_restore=False)
     
     # Build the IPA - will use merged NuGet.config
-    # TODO: Remove /p:TargetsCurrent=true once https://github.com/dotnet/performance/issues/5055 is resolved
-    precommands.execute(['/p:EnableCodeSigning=false', '/p:ApplicationId=net.dot.mauitesting', '/p:TargetsCurrent=true'])
+    precommands.execute(['/p:EnableCodeSigning=false', '/p:ApplicationId=net.dot.mauitesting'])
     # NuGet.config is automatically restored after this block
 
 # Remove the aab files as we don't need them, this saves space

--- a/src/scenarios/mauiios/pre.py
+++ b/src/scenarios/mauiios/pre.py
@@ -39,6 +39,6 @@ if precommands.output:
 remove_aab_files(output_dir)
 
 # Extract the versions of used SDKs from the linked folder DLLs
-version_dict = get_sdk_versions(rf"./{const.APPDIR}/obj/Release/{precommands.framework}/ios-arm64/linked", False)
+version_dict = get_sdk_versions(rf"./{const.APPDIR}/obj/{precommands.configuration}/{precommands.framework}/ios-arm64/linked", False)
 versions_write_json(version_dict, rf"{output_dir}/versions.json")
-print(f"Versions: {version_dict} from location " + rf"./{const.APPDIR}/obj/Release/{precommands.framework}/ios-arm64/linked")
+print(f"Versions: {version_dict} from location " + rf"./{const.APPDIR}/obj/{precommands.configuration}/{precommands.framework}/ios-arm64/linked")

--- a/src/scenarios/mauiios/pre.py
+++ b/src/scenarios/mauiios/pre.py
@@ -14,12 +14,12 @@ from test import EXENAME
 setup_loggers(True)
 
 precommands = PreCommands()
-install_latest_maui(precommands)
-precommands.print_dotnet_info()
 
 # Use context manager to temporarily merge MAUI's NuGet feeds into repo config
-# This ensures both dotnet new and dotnet build/publish have access to MAUI packages
+# This ensures dotnet package search, dotnet new, and dotnet build/publish have access to MAUI packages
 with MauiNuGetConfigContext(precommands.framework):
+    install_latest_maui(precommands)
+    precommands.print_dotnet_info()
     # Setup the Maui folder - will use merged NuGet.config with MAUI feeds
     precommands.new(template='maui',
                     output_dir=const.APPDIR,
@@ -31,7 +31,7 @@ with MauiNuGetConfigContext(precommands.framework):
     # Build the IPA - will use merged NuGet.config
     # TODO: Remove /p:TargetsCurrent=true once https://github.com/dotnet/performance/issues/5055 is resolved
     precommands.execute(['/p:EnableCodeSigning=false', '/p:ApplicationId=net.dot.mauitesting', '/p:TargetsCurrent=true'])
-# NuGet.config is automatically restored after this block
+    # NuGet.config is automatically restored after this block
 
 # Remove the aab files as we don't need them, this saves space
 output_dir = const.PUBDIR

--- a/src/scenarios/mauiios/pre.py
+++ b/src/scenarios/mauiios/pre.py
@@ -28,8 +28,9 @@ with MauiNuGetConfigContext(precommands.framework):
                     working_directory=sys.path[0],
                     no_restore=False)
     
-    # Build the IPA - will also use merged NuGet.config
-    precommands.execute(['/p:EnableCodeSigning=false', '/p:ApplicationId=net.dot.mauitesting'])
+    # Build the IPA - will use merged NuGet.config
+    # TODO: Remove /p:TargetsCurrent=true once https://github.com/dotnet/performance/issues/5055 is resolved
+    precommands.execute(['/p:EnableCodeSigning=false', '/p:ApplicationId=net.dot.mauitesting', '/p:TargetsCurrent=true'])
 # NuGet.config is automatically restored after this block
 
 # Remove the aab files as we don't need them, this saves space

--- a/src/scenarios/mauiios/test.py
+++ b/src/scenarios/mauiios/test.py
@@ -1,6 +1,7 @@
 '''
 Mobile Maui App
 '''
+import os
 from shared.const import PUBDIR
 from shared.runner import TestTraits, Runner
 from shared.versionmanager import versions_read_json_file_save_env
@@ -8,7 +9,7 @@ from shared.versionmanager import versions_read_json_file_save_env
 EXENAME = 'MauiiOSDefault'
 
 if __name__ == "__main__":    
-    versions_read_json_file_save_env(rf"./{PUBDIR}/versions.json")
+    versions_read_json_file_save_env(os.path.join(".", PUBDIR, "versions.json"))
 
     traits = TestTraits(exename=EXENAME, 
                         guiapp='false',

--- a/src/scenarios/mauisamplecontentandroid/pre.py
+++ b/src/scenarios/mauisamplecontentandroid/pre.py
@@ -1,6 +1,7 @@
 '''
 pre-command
 '''
+import os
 import shutil
 import sys
 from performance.logger import setup_loggers, getLogger
@@ -40,7 +41,10 @@ if precommands.output:
     output_dir = precommands.output
 remove_aab_files(output_dir)
 
-# Extract the versions of used SDKs from the linked folder DLLs
-version_dict = get_sdk_versions(rf".\{const.APPDIR}\obj\Release\{precommands.framework}\android-arm64\linked")
-versions_write_json(version_dict, rf"{output_dir}\versions.json")
-print(f"Versions: {version_dict} from location " + rf".\{const.APPDIR}\obj\Release\{precommands.framework}\android-arm64\linked")
+# Extract the versions of used SDKs from the linked folder DLLs (Release) or assets folder (Debug)
+dll_folder = os.path.join(".", const.APPDIR, "obj", precommands.configuration, precommands.framework, "android-arm64", "linked")
+if not os.path.isdir(dll_folder):
+    dll_folder = os.path.join(".", const.APPDIR, "obj", precommands.configuration, precommands.framework, "android-arm64", "android", "assets", "arm64-v8a")
+version_dict = get_sdk_versions(dll_folder)
+versions_write_json(version_dict, os.path.join(output_dir, "versions.json"))
+print(f"Versions: {version_dict} from location {dll_folder}")

--- a/src/scenarios/mauisamplecontentandroid/pre.py
+++ b/src/scenarios/mauisamplecontentandroid/pre.py
@@ -16,12 +16,11 @@ logger.info(f"Starting pre-command for MAUI Sample Content template app (dotnet 
 
 precommands = PreCommands()
 
-install_latest_maui(precommands)
-precommands.print_dotnet_info()
-
 # Use context manager to temporarily merge MAUI's NuGet feeds into repo config
-# This ensures both dotnet new and dotnet build/publish have access to MAUI packages
+# This ensures dotnet package search, dotnet new, and dotnet build/publish have access to MAUI packages
 with MauiNuGetConfigContext(precommands.framework):
+    install_latest_maui(precommands)
+    precommands.print_dotnet_info()
     # Setup the Maui folder - will use merged NuGet.config with MAUI feeds
     precommands.new(template='maui',
                     output_dir=const.APPDIR,
@@ -33,7 +32,7 @@ with MauiNuGetConfigContext(precommands.framework):
     
     # Build the APK - will use merged NuGet.config
     precommands.execute([])
-# NuGet.config is automatically restored after this block
+    # NuGet.config is automatically restored after this block
 
 # Remove the aab files as we don't need them, this saves space
 output_dir = const.PUBDIR

--- a/src/scenarios/mauisamplecontentandroid/pre.py
+++ b/src/scenarios/mauisamplecontentandroid/pre.py
@@ -5,7 +5,7 @@ import shutil
 import sys
 from performance.logger import setup_loggers, getLogger
 from shared import const
-from shared.mauisharedpython import remove_aab_files, install_latest_maui
+from shared.mauisharedpython import remove_aab_files, install_latest_maui, MauiNuGetConfigContext
 from shared.precommands import PreCommands
 from shared.versionmanager import versions_write_json, get_sdk_versions
 from test import EXENAME
@@ -19,17 +19,21 @@ precommands = PreCommands()
 install_latest_maui(precommands)
 precommands.print_dotnet_info()
 
-# Setup the Maui folder
-precommands.new(template='maui',
-                output_dir=const.APPDIR,
-                bin_dir=const.BINDIR,
-                exename=EXENAME,
-                working_directory=sys.path[0],
-                no_restore=False,
-                extra_args=['--sample-content'])
-
-# Build the APK
-precommands.execute([])
+# Use context manager to temporarily merge MAUI's NuGet feeds into repo config
+# This ensures both dotnet new and dotnet build/publish have access to MAUI packages
+with MauiNuGetConfigContext(precommands.framework):
+    # Setup the Maui folder - will use merged NuGet.config with MAUI feeds
+    precommands.new(template='maui',
+                    output_dir=const.APPDIR,
+                    bin_dir=const.BINDIR,
+                    exename=EXENAME,
+                    working_directory=sys.path[0],
+                    no_restore=False,
+                    extra_args=['--sample-content'])
+    
+    # Build the APK - will use merged NuGet.config
+    precommands.execute([])
+# NuGet.config is automatically restored after this block
 
 # Remove the aab files as we don't need them, this saves space
 output_dir = const.PUBDIR

--- a/src/scenarios/mauisamplecontentandroid/test.py
+++ b/src/scenarios/mauisamplecontentandroid/test.py
@@ -1,6 +1,7 @@
 '''
 Mobile Maui App
 '''
+import os
 from shared.const import PUBDIR
 from shared.runner import TestTraits, Runner
 from shared.versionmanager import versions_read_json_file_save_env
@@ -8,7 +9,7 @@ from shared.versionmanager import versions_read_json_file_save_env
 EXENAME = 'MauiSampleContentAndroid'
 
 if __name__ == "__main__":    
-    versions_read_json_file_save_env(rf".\{PUBDIR}\versions.json")
+    versions_read_json_file_save_env(os.path.join(".", PUBDIR, "versions.json"))
 
     traits = TestTraits(exename=EXENAME, 
                         guiapp='false',

--- a/src/scenarios/mauisamplecontentios/post.py
+++ b/src/scenarios/mauisamplecontentios/post.py
@@ -1,0 +1,7 @@
+'''
+post cleanup script
+'''
+
+from shared.postcommands import clean_directories
+
+clean_directories()

--- a/src/scenarios/mauisamplecontentios/pre.py
+++ b/src/scenarios/mauisamplecontentios/pre.py
@@ -1,0 +1,47 @@
+'''
+pre-command
+'''
+import shutil
+import sys
+import subprocess
+from performance.logger import setup_loggers, getLogger
+from shared import const
+from shared.mauisharedpython import remove_aab_files, install_latest_maui, MauiNuGetConfigContext
+from shared.precommands import PreCommands
+from shared.versionmanager import versions_write_json, get_sdk_versions
+from test import EXENAME
+
+setup_loggers(True)
+logger = getLogger(__name__)
+logger.info(f"Starting pre-command for MAUI Sample Content iOS template app (dotnet new maui --sample-content)")
+
+precommands = PreCommands()
+
+# Use context manager to temporarily merge MAUI's NuGet feeds into repo config
+# This ensures dotnet package search, dotnet new, and dotnet build/publish have access to MAUI packages
+with MauiNuGetConfigContext(precommands.framework):
+    install_latest_maui(precommands)
+    precommands.print_dotnet_info()
+    # Setup the Maui folder - will use merged NuGet.config with MAUI feeds
+    precommands.new(template='maui',
+                    output_dir=const.APPDIR,
+                    bin_dir=const.BINDIR,
+                    exename=EXENAME,
+                    working_directory=sys.path[0],
+                    no_restore=False,
+                    extra_args=['--sample-content'])
+    
+    # Build the IPA - will use merged NuGet.config
+    precommands.execute(['/p:EnableCodeSigning=false', '/p:ApplicationId=net.dot.mauisamplecontenttesting'])
+    # NuGet.config is automatically restored after this block
+
+# Remove the aab files as we don't need them, this saves space
+output_dir = const.PUBDIR
+if precommands.output:
+    output_dir = precommands.output
+remove_aab_files(output_dir)
+
+# Extract the versions of used SDKs from the linked folder DLLs
+version_dict = get_sdk_versions(rf"./{const.APPDIR}/obj/Release/{precommands.framework}/ios-arm64/linked", False)
+versions_write_json(version_dict, rf"{output_dir}/versions.json")
+print(f"Versions: {version_dict} from location " + rf"./{const.APPDIR}/obj/Release/{precommands.framework}/ios-arm64/linked")

--- a/src/scenarios/mauisamplecontentios/test.py
+++ b/src/scenarios/mauisamplecontentios/test.py
@@ -1,0 +1,16 @@
+'''
+Mobile Maui App
+'''
+from shared.const import PUBDIR
+from shared.runner import TestTraits, Runner
+from shared.versionmanager import versions_read_json_file_save_env
+
+EXENAME = 'MauiSampleContentiOSDefault'
+
+if __name__ == "__main__":    
+    versions_read_json_file_save_env(rf"./{PUBDIR}/versions.json")
+
+    traits = TestTraits(exename=EXENAME, 
+                        guiapp='false',
+                        )
+    Runner(traits).run()

--- a/src/scenarios/netandroid/pre.py
+++ b/src/scenarios/netandroid/pre.py
@@ -1,6 +1,7 @@
 '''
 pre-command
 '''
+import os
 import shutil
 import sys
 from performance.logger import setup_loggers, getLogger
@@ -37,7 +38,10 @@ if precommands.output:
     output_dir = precommands.output
 remove_aab_files(output_dir)
 
-# Extract the versions of used SDKs from the linked folder DLLs
-version_dict = get_sdk_versions(rf".\{const.APPDIR}\obj\Release\{precommands.framework}\android-arm64\linked")
-versions_write_json(version_dict, rf"{output_dir}\versions.json")
-print(f"Versions: {version_dict} from location " + rf".\{const.APPDIR}\obj\Release\{precommands.framework}\android-arm64\linked")
+# Extract the versions of used SDKs from the linked folder DLLs (Release) or assets folder (Debug)
+dll_folder = os.path.join(".", const.APPDIR, "obj", precommands.configuration, precommands.framework, "android-arm64", "linked")
+if not os.path.isdir(dll_folder):
+    dll_folder = os.path.join(".", const.APPDIR, "obj", precommands.configuration, precommands.framework, "android-arm64", "android", "assets", "arm64-v8a")
+version_dict = get_sdk_versions(dll_folder)
+versions_write_json(version_dict, os.path.join(output_dir, "versions.json"))
+print(f"Versions: {version_dict} from location {dll_folder}")

--- a/src/scenarios/netandroid/pre.py
+++ b/src/scenarios/netandroid/pre.py
@@ -5,7 +5,7 @@ import shutil
 import sys
 from performance.logger import setup_loggers, getLogger
 from shared import const
-from shared.mauisharedpython import remove_aab_files,install_latest_maui
+from shared.mauisharedpython import remove_aab_files,install_latest_maui, MauiNuGetConfigContext
 from shared.precommands import PreCommands
 from shared.versionmanager import versions_write_json, get_sdk_versions
 from test import EXENAME
@@ -16,19 +16,20 @@ logger.info("Starting pre-command for .NET Android template app (dotnet new andr
 
 precommands = PreCommands()
 
-install_latest_maui(precommands)
-precommands.print_dotnet_info()
+with MauiNuGetConfigContext(precommands.framework):
+    install_latest_maui(precommands)
+    precommands.print_dotnet_info()
 
-# Setup the app folder
-precommands.new(template='android',
-                output_dir=const.APPDIR,
-                bin_dir=const.BINDIR,
-                exename=EXENAME,
-                working_directory=sys.path[0],
-                no_restore=False)
+    # Setup the app folder
+    precommands.new(template='android',
+                    output_dir=const.APPDIR,
+                    bin_dir=const.BINDIR,
+                    exename=EXENAME,
+                    working_directory=sys.path[0],
+                    no_restore=False)
 
-# Build the APK
-precommands.execute([])
+    # Build the APK
+    precommands.execute([])
 
 # Remove the aab files as we don't need them, this saves space
 output_dir = const.PUBDIR

--- a/src/scenarios/netandroid/test.py
+++ b/src/scenarios/netandroid/test.py
@@ -1,6 +1,7 @@
 '''
 .NET Android Default App
 '''
+import os
 from shared.const import PUBDIR
 from shared.runner import TestTraits, Runner
 from shared.versionmanager import versions_read_json_file_save_env
@@ -8,7 +9,7 @@ from shared.versionmanager import versions_read_json_file_save_env
 EXENAME = 'NetAndroidDefault'
 
 if __name__ == "__main__":    
-    versions_read_json_file_save_env(rf".\{PUBDIR}\versions.json")
+    versions_read_json_file_save_env(os.path.join(".", PUBDIR, "versions.json"))
 
     traits = TestTraits(exename=EXENAME, 
                         guiapp='false',

--- a/src/scenarios/netios/pre.py
+++ b/src/scenarios/netios/pre.py
@@ -36,6 +36,6 @@ if precommands.output:
 remove_aab_files(output_dir)
 
 # Extract the versions of used SDKs from the linked folder DLLs
-version_dict = get_sdk_versions(rf"./{const.APPDIR}/obj/Release/{precommands.framework}/ios-arm64/linked", False)
+version_dict = get_sdk_versions(rf"./{const.APPDIR}/obj/{precommands.configuration}/{precommands.framework}/ios-arm64/linked", False)
 versions_write_json(version_dict, rf"{output_dir}/versions.json")
-print(f"Versions: {version_dict} from location " + rf"./{const.APPDIR}/obj/Release/{precommands.framework}/ios-arm64/linked")
+print(f"Versions: {version_dict} from location " + rf"./{const.APPDIR}/obj/{precommands.configuration}/{precommands.framework}/ios-arm64/linked")

--- a/src/scenarios/netios/pre.py
+++ b/src/scenarios/netios/pre.py
@@ -27,8 +27,7 @@ with MauiNuGetConfigContext(precommands.framework):
                     no_restore=False)
 
     # Build the IPA - will use merged NuGet.config
-    # TODO: Remove /p:TargetsCurrent=true once https://github.com/dotnet/performance/issues/5055 is resolved
-    precommands.execute(['/p:EnableCodeSigning=false', '/p:ApplicationId=net.dot.xamarintesting', '/p:TargetsCurrent=true'])
+    precommands.execute(['/p:EnableCodeSigning=false', '/p:ApplicationId=net.dot.xamarintesting'])
 
 # Remove the aab files as we don't need them, this saves space
 output_dir = const.PUBDIR

--- a/src/scenarios/netios/pre.py
+++ b/src/scenarios/netios/pre.py
@@ -5,7 +5,7 @@ import shutil
 import sys
 from performance.logger import setup_loggers, getLogger
 from shared import const
-from shared.mauisharedpython import remove_aab_files, install_latest_maui
+from shared.mauisharedpython import remove_aab_files, install_latest_maui, MauiNuGetConfigContext
 from shared.precommands import PreCommands
 from shared.versionmanager import versions_write_json, get_sdk_versions
 from test import EXENAME
@@ -13,20 +13,22 @@ from test import EXENAME
 setup_loggers(True)
 
 precommands = PreCommands()
-install_latest_maui(precommands)
-precommands.print_dotnet_info()
 
-# Setup the .NET iOS folder
-precommands.new(template='ios',
-                output_dir=const.APPDIR,
-                bin_dir=const.BINDIR,
-                exename=EXENAME,
-                working_directory=sys.path[0],
-                no_restore=False)
+with MauiNuGetConfigContext(precommands.framework):
+    install_latest_maui(precommands)
+    precommands.print_dotnet_info()
 
-# Build the IPA - will use merged NuGet.config
-# TODO: Remove /p:TargetsCurrent=true once https://github.com/dotnet/performance/issues/5055 is resolved
-precommands.execute(['/p:EnableCodeSigning=false', '/p:ApplicationId=net.dot.xamarintesting', '/p:TargetsCurrent=true'])
+    # Setup the .NET iOS folder
+    precommands.new(template='ios',
+                    output_dir=const.APPDIR,
+                    bin_dir=const.BINDIR,
+                    exename=EXENAME,
+                    working_directory=sys.path[0],
+                    no_restore=False)
+
+    # Build the IPA - will use merged NuGet.config
+    # TODO: Remove /p:TargetsCurrent=true once https://github.com/dotnet/performance/issues/5055 is resolved
+    precommands.execute(['/p:EnableCodeSigning=false', '/p:ApplicationId=net.dot.xamarintesting', '/p:TargetsCurrent=true'])
 
 # Remove the aab files as we don't need them, this saves space
 output_dir = const.PUBDIR

--- a/src/scenarios/netios/pre.py
+++ b/src/scenarios/netios/pre.py
@@ -24,8 +24,9 @@ precommands.new(template='ios',
                 working_directory=sys.path[0],
                 no_restore=False)
 
-# Build the APK
-precommands.execute(['/p:EnableCodeSigning=false', '/p:ApplicationId=net.dot.xamarintesting'])
+# Build the IPA - will use merged NuGet.config
+# TODO: Remove /p:TargetsCurrent=true once https://github.com/dotnet/performance/issues/5055 is resolved
+precommands.execute(['/p:EnableCodeSigning=false', '/p:ApplicationId=net.dot.xamarintesting', '/p:TargetsCurrent=true'])
 
 # Remove the aab files as we don't need them, this saves space
 output_dir = const.PUBDIR

--- a/src/scenarios/netios/test.py
+++ b/src/scenarios/netios/test.py
@@ -1,6 +1,7 @@
 '''
 Mobile .NET iOS Default App
 '''
+import os
 from shared.const import PUBDIR
 from shared.runner import TestTraits, Runner
 from shared.versionmanager import versions_read_json_file_save_env
@@ -8,7 +9,7 @@ from shared.versionmanager import versions_read_json_file_save_env
 EXENAME = 'NetiOSDefault'
 
 if __name__ == "__main__":    
-    versions_read_json_file_save_env(rf"./{PUBDIR}/versions.json")
+    versions_read_json_file_save_env(os.path.join(".", PUBDIR, "versions.json"))
 
     traits = TestTraits(exename=EXENAME, 
                         guiapp='false',

--- a/src/scenarios/shared/codefixes.py
+++ b/src/scenarios/shared/codefixes.py
@@ -22,10 +22,14 @@ def writefile(file: str, lines: list[str]):
 # insert string after the first occurance of the search string
 def insert_after(file: str, search: str, insert: str):
     lines = readfile(file)
+    found = False
     for i in range(len(lines)):
         if search in lines[i]:
             lines.insert(i+1, ("%s\n" % insert))
+            found = True
             break
+    if not found:
+        raise Exception(f"insert_after: search string '{search}' not found in {file}")
     writefile(file, lines)
 
 def replace_line(file: str, search: str, replace: str):

--- a/src/scenarios/shared/devicepowerconsumption.py
+++ b/src/scenarios/shared/devicepowerconsumption.py
@@ -93,7 +93,10 @@ class DevicePowerConsumptionHelper(object):
             copytree(TRACEDIR, os.path.join(helix_upload_dir, 'traces'))
             if traits.upload_to_perflab_container:
                 import upload
-                upload.upload(self.reportjson, upload_container, UPLOAD_QUEUE, UPLOAD_STORAGE_URI)
+                upload_code = upload.upload(self.reportjson, upload_container, UPLOAD_QUEUE, UPLOAD_STORAGE_URI)
+                getLogger().info("DevicePowerConsumption Upload Code: " + str(upload_code))
+                if upload_code != 0:
+                    sys.exit(upload_code)
 
     def runtestsandroid(self, packagepath: str, packagename: str, testiterations: int, runtimeseconds: int, closeToStartDelay: int, traits: TestTraits):
         getLogger().info("Clearing potential previous run nettraces")

--- a/src/scenarios/shared/mauisharedpython.py
+++ b/src/scenarios/shared/mauisharedpython.py
@@ -21,7 +21,7 @@ def generate_maui_rollback_dict(target_framework: str):
     This eliminates the need to maintain MAUI dependencies in the performance repo's Version.Details.xml.
     
     Args:
-        target_framework: Target framework to determine which MAUI branch to use (e.g., "net10.0")
+        target_framework: Target framework to determine which MAUI branch to use (e.g., "net11.0")
     
     Returns:
         Dictionary mapping rollback package names to version/band strings
@@ -159,13 +159,13 @@ def extract_latest_dotnet_feed_from_nuget_config(path: str, offset: int = 0) -> 
 
     return target_feed
 
-def download_maui_nuget_config(target_framework: str = "net10.0", output_filename: str = "MauiNuGet.config") -> str:
+def download_maui_nuget_config(target_framework: str = "net11.0", output_filename: str = "MauiNuGet.config") -> str:
     '''
         Download MAUI's NuGet.config from the appropriate branch.
         Returns the path to the downloaded config file.
         
         Args:
-            target_framework: Target framework to determine which branch to use (e.g., "net10.0")
+            target_framework: Target framework to determine which branch to use (e.g., "net11.0")
             output_filename: Name of the file to save the downloaded config
     '''
     # Extract base framework version (e.g., "net10.0" from "net10.0-android")

--- a/src/scenarios/shared/mauisharedpython.py
+++ b/src/scenarios/shared/mauisharedpython.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shutil
 import xml.etree.ElementTree as ET
 import re
 import urllib.request
@@ -14,12 +15,24 @@ def remove_aab_files(output_dir="."):
         if file.endswith(".aab"):
             os.remove(os.path.join(output_dir, file))  
 
-def generate_maui_rollback_dict():
-    # Generate and use rollback based on Version.Details.xml
-    # Generate the list of versions starts to get and the names to save them as in the rollback.
-    # These mapping values were taken from the previously generated rollback files for the maui workload. There should be at least one entry for each
-    # of the Maui Workload dependencies in the /eng/Version.Details.xml file, aside from Microsoft.NET.Sdk.
-    # If there are errors in the future, reach out to the maui team.
+def generate_maui_rollback_dict(target_framework: str):
+    '''
+    Generate MAUI workload rollback dictionary by downloading and parsing MAUI's Version.Details.xml.
+    This eliminates the need to maintain MAUI dependencies in the performance repo's Version.Details.xml.
+    
+    Args:
+        target_framework: Target framework to determine which MAUI branch to use (e.g., "net10.0")
+    
+    Returns:
+        Dictionary mapping rollback package names to version/band strings
+    '''
+    # Extract base framework version
+    if '-' in target_framework:
+        target_framework_wo_platform = target_framework.split('-')[0]
+    else:
+        target_framework_wo_platform = target_framework
+    
+    # Mapping of rollback names to XML dependency names
     rollback_name_to_xml_name_mappings: dict[str, str] = {
         "microsoft.net.sdk.android" : "Microsoft.Android.Sdk",
         "microsoft.net.sdk.ios" : "Microsoft.iOS.Sdk",
@@ -31,48 +44,54 @@ def generate_maui_rollback_dict():
         "microsoft.net.sdk.mono.emscripten.current" : "Microsoft.NET.Workload.Emscripten.Current"
     }
     rollback_dict: dict[str, str] = {}
+    
+    # Download MAUI's Version.Details.xml
+    maui_version_url = f'https://raw.githubusercontent.com/dotnet/maui/{target_framework_wo_platform}/eng/Version.Details.xml'
+    getLogger().info(f"Downloading MAUI Version.Details.xml from {maui_version_url} for rollback generation")
+    
+    try:
+        with urllib.request.urlopen(maui_version_url) as response:
+            version_details_xml = response.read().decode('utf-8')
+    except Exception as e:
+        getLogger().error(f"Failed to download MAUI Version.Details.xml: {e}")
+        raise ValueError(f"Cannot generate rollback dict without MAUI Version.Details.xml: {e}")
+    
+    root = ET.fromstring(version_details_xml)
 
-    # Load in the Version.Details.xml file
-    with open(os.path.join(get_repo_root_path(), "eng", "Version.Details.xml"), encoding="utf-8") as f:
-        version_details_xml = f.read()
-        root = ET.fromstring(version_details_xml)
-
-    # Get the General Band version from the Version.Details.xml file sdk version
+    # Get the General Band version from the SDK version
     general_version_obj = root.find(".//Dependency[@Name='Microsoft.NET.Sdk']")
     if general_version_obj is not None:
         full_band_version_holder = general_version_obj.get("Version")
         if full_band_version_holder is None:
-            raise ValueError("Unable to find Microsoft.NET.Sdk with proper version in Version.Details.xml")
+            raise ValueError("Unable to find Microsoft.NET.Sdk with proper version in MAUI's Version.Details.xml")
         match = re.search(r'^\d+\.\d+\.\d+(\-(preview|rc|alpha).\d+)?', full_band_version_holder)
         if match:
             default_band_version = match.group(0)
         else:
-            raise ValueError("Unable to find general version in Version.Details.xml")
+            raise ValueError("Unable to find general version in MAUI's Version.Details.xml")
     else:
-        raise ValueError("Unable to find general version in Version.Details.xml")
+        raise ValueError("Unable to find general version in MAUI's Version.Details.xml")
 
-    # Get the available versions from the Version.Details.xml file
+    # Get the available versions from MAUI's Version.Details.xml
     dependencies = root.findall(".//Dependency[@Name]")
     for rollback_name, xml_name in rollback_name_to_xml_name_mappings.items():
         for dependency in dependencies:
             if dependency.attrib['Name'].startswith(xml_name):
                 workload_version = dependency.get("Version")
                 if workload_version is None:
-                    raise ValueError(f"Unable to find {xml_name} with proper version in the provided xml file")
+                    raise ValueError(f"Unable to find {xml_name} with proper version in MAUI's Version.Details.xml")
 
-                # Use the band version based on what the maui upstream currently has. This is necessary if they hardcode the version.
-                band_name_match_string = rf"^\s*Mapping_{xml_name}:(\S*)"
-                band_version_mapping = re.search(band_name_match_string, version_details_xml, flags=re.MULTILINE)
-                if band_version_mapping is None:
-                    raise ValueError(f"Unable to find band version mapping for match {band_name_match_string} in Version.Details.xml")
-                if band_version_mapping.group(1) == "default":
-                    band_version = default_band_version
-                else:
-                    band_version = band_version_mapping.group(1)
+                # Use the band version based on what MAUI upstream currently has
+                # Note: MAUI doesn't have Mapping_ comments in their Version.Details.xml, 
+                # so we use the default band version extracted from Microsoft.NET.Sdk
+                band_version = default_band_version
                 rollback_dict[rollback_name] = f"{workload_version}/{band_version}"
+                getLogger().debug(f"Rollback entry: {rollback_name} = {workload_version}/{band_version}")
                 break
         if rollback_name not in rollback_dict:
-            raise ValueError(f"Unable to find {rollback_name} with proper version in Version.Details.xml")
+            raise ValueError(f"Unable to find {rollback_name} with proper version in MAUI's Version.Details.xml")
+    
+    getLogger().info(f"Generated rollback dict with {len(rollback_dict)} entries from MAUI upstream")
     return rollback_dict
 
 def dump_dict_to_json_file(dump_dict: dict[str, str], file_name: str):
@@ -90,7 +109,8 @@ def install_versioned_maui(precommands: PreCommands):
 
     workload_install_args = ['--configfile', 'MauiNuGet.config', '--skip-sign-check']
     if int(target_framework_wo_platform.split('.')[0][3:]) > 8: # Use the rollback file for versions greater than 8 (should be set to only run for versions where we also use a specific dotnet version from the yml)
-        rollback_dict = generate_maui_rollback_dict()
+        # Generate rollback dict directly from MAUI's Version.Details.xml (no local dependency needed)
+        rollback_dict = generate_maui_rollback_dict(target_framework_wo_platform)
         dump_dict_to_json_file(rollback_dict, f"rollback_{target_framework_wo_platform}.json")
         workload_install_args += ['--from-rollback-file', f'rollback_{target_framework_wo_platform}.json']
 
@@ -138,6 +158,145 @@ def extract_latest_dotnet_feed_from_nuget_config(path: str, offset: int = 0) -> 
     target_feed = dotnet_feeds[target_version]
 
     return target_feed
+
+def download_maui_nuget_config(target_framework: str = "net10.0", output_filename: str = "MauiNuGet.config") -> str:
+    '''
+        Download MAUI's NuGet.config from the appropriate branch.
+        Returns the path to the downloaded config file.
+        
+        Args:
+            target_framework: Target framework to determine which branch to use (e.g., "net10.0")
+            output_filename: Name of the file to save the downloaded config
+    '''
+    # Extract base framework version (e.g., "net10.0" from "net10.0-android")
+    if '-' in target_framework:
+        target_framework_wo_platform = target_framework.split('-')[0]
+    else:
+        target_framework_wo_platform = target_framework
+    
+    url = f'https://raw.githubusercontent.com/dotnet/maui/{target_framework_wo_platform}/NuGet.config'
+    getLogger().info(f"Downloading MAUI NuGet.config from {url}")
+    
+    try:
+        with open(output_filename, "wb") as f:
+            with urllib.request.urlopen(url) as response:
+                f.write(response.read())
+        getLogger().info(f"Successfully downloaded MAUI NuGet.config to {output_filename}")
+        return os.path.abspath(output_filename)
+    except Exception as e:
+        getLogger().error(f"Failed to download MAUI NuGet.config: {e}")
+        raise
+
+class MauiNuGetConfigContext:
+    '''
+    Context manager that temporarily merges MAUI's package sources into the repo's NuGet.config.
+    This is necessary because dotnet new doesn't support --configfile parameter.
+    Finds NuGet.config relative to current working directory to support both local and CorrelationStaging scenarios.
+    '''
+    def __init__(self, target_framework: str):
+        self.target_framework = target_framework
+        # Find NuGet.config by walking up from current directory
+        self.repo_nuget_config = self._find_repo_nuget_config()
+        self.backup_path = self.repo_nuget_config + ".maui_backup"
+        self.maui_config_path = None
+    
+    def _find_repo_nuget_config(self) -> str:
+        '''
+        Find the repo's NuGet.config by walking up from the current directory.
+        This works for both local (c:/Users/.../performance) and pipeline (D:/a/1/s/performance/CorrelationStaging/payload/performance) scenarios.
+        '''
+        current = os.getcwd()
+        while current:
+            nuget_config_path = os.path.join(current, "NuGet.config")
+            if os.path.exists(nuget_config_path):
+                getLogger().info(f"Found NuGet.config at: {nuget_config_path}")
+                return nuget_config_path
+            
+            parent = os.path.dirname(current)
+            if parent == current:  # Reached filesystem root
+                break
+            current = parent
+        
+        # Fallback to get_repo_root_path() if not found by walking up
+        fallback_path = os.path.join(get_repo_root_path(), "NuGet.config")
+        getLogger().warning(f"Could not find NuGet.config by walking up, using fallback: {fallback_path}")
+        return fallback_path
+        
+    def __enter__(self):
+        getLogger().info("Setting up MAUI NuGet.config merge...")
+        
+        # Download MAUI's NuGet.config to a temporary location in the same directory as repo NuGet.config
+        temp_maui_config = os.path.join(os.path.dirname(self.repo_nuget_config), "MauiNuGet.config")
+        self.maui_config_path = download_maui_nuget_config(self.target_framework, temp_maui_config)
+        
+        # Backup the repo's NuGet.config
+        shutil.copy2(self.repo_nuget_config, self.backup_path)
+        getLogger().info(f"Backed up repo NuGet.config to {self.backup_path}")
+        
+        # Parse both configs
+        repo_tree = ET.parse(self.repo_nuget_config)
+        repo_root = repo_tree.getroot()
+        maui_tree = ET.parse(self.maui_config_path)
+        maui_root = maui_tree.getroot()
+        
+        # Get package sources from both
+        repo_sources = repo_root.find(".//packageSources")
+        maui_sources = maui_root.find(".//packageSources")
+        
+        if repo_sources is None or maui_sources is None:
+            getLogger().error("Could not find packageSources in NuGet.config files")
+            raise ValueError("Invalid NuGet.config structure")
+        
+        # Get existing source keys to avoid duplicates
+        existing_keys = {add_elem.get("key") for add_elem in repo_sources.findall("add") if add_elem.get("key")}
+        
+        # Add MAUI sources that don't exist in repo config
+        # Filter out placeholder sources that MAUI uses for their build system
+        placeholder_patterns = ["PLACEHOLDER", "local", "nuget-only"]
+        added_count = 0
+        for add_elem in maui_sources.findall("add"):
+            key = add_elem.get("key")
+            value = add_elem.get("value")
+            
+            # Skip if key already exists in repo config
+            if not key or key in existing_keys:
+                continue
+            
+            # Skip placeholder sources (local, nuget-only, or any with PLACEHOLDER in value)
+            if any(pattern.lower() in key.lower() for pattern in placeholder_patterns):
+                getLogger().debug(f"Skipping placeholder source: {key}")
+                continue
+            if value and "PLACEHOLDER" in value:
+                getLogger().debug(f"Skipping placeholder source with placeholder value: {key}")
+                continue
+            
+            # Add valid source
+            repo_sources.append(add_elem)
+            added_count += 1
+            getLogger().debug(f"Added package source: {key}")
+        
+        getLogger().info(f"Added {added_count} package sources from MAUI NuGet.config")
+        
+        # Write the merged config back
+        repo_tree.write(self.repo_nuget_config, encoding="utf-8", xml_declaration=True)
+        getLogger().info("Merged MAUI package sources into repo NuGet.config")
+        
+        return self
+        
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        getLogger().info("Restoring original NuGet.config...")
+        
+        # Restore the original NuGet.config
+        if os.path.exists(self.backup_path):
+            shutil.move(self.backup_path, self.repo_nuget_config)
+            getLogger().info("Restored original NuGet.config")
+        
+        # Clean up the downloaded MAUI config
+        if self.maui_config_path and os.path.exists(self.maui_config_path):
+            os.remove(self.maui_config_path)
+            getLogger().debug("Cleaned up temporary MAUI NuGet.config")
+        
+        return False  # Don't suppress exceptions
 
 def install_latest_maui(
         precommands: PreCommands, 

--- a/src/scenarios/shared/memoryconsumption.py
+++ b/src/scenarios/shared/memoryconsumption.py
@@ -86,7 +86,10 @@ class MemoryConsumptionWrapper(object):
             copytree(TRACEDIR, os.path.join(helix_upload_dir, 'traces'))
             if traits.upload_to_perflab_container:
                 import upload
-                upload.upload(self.reportjson, upload_container, UPLOAD_QUEUE, UPLOAD_STORAGE_URI)
+                upload_code = upload.upload(self.reportjson, upload_container, UPLOAD_QUEUE, UPLOAD_STORAGE_URI)
+                getLogger().info("MemoryConsumption Upload Code: " + str(upload_code))
+                if upload_code != 0:
+                    sys.exit(upload_code)
 
     def runtests(self, traits: TestTraits):
         '''

--- a/src/scenarios/shared/precommands.py
+++ b/src/scenarios/shared/precommands.py
@@ -93,7 +93,6 @@ class PreCommands:
         self.operation = args.operation
         self.framework = args.framework
         self.runtime_identifier = args.runtime
-        self.nativeaot = args.nativeaot
         self.msbuild = args.msbuild
         print(self.msbuild)
         self.msbuildstatic = args.msbuildstatic
@@ -154,10 +153,6 @@ class PreCommands:
                             dest='runtime',
                             metavar='runtime',
                             help='runtime for build or publish - ex: win-x64')
-        parser.add_argument('-n', '--nativeaot',
-                            dest='nativeaot',
-                            metavar='nativeaot',
-                            help='use Native AOT runtime for build or publish')
         parser.add_argument('--msbuild',
                             dest='msbuild',
                             metavar='msbuild',
@@ -211,9 +206,6 @@ class PreCommands:
                 build_args.append('--self-contained')
             elif self.no_self_contained:
                 build_args.append('--no-self-contained')
-            if self.nativeaot:
-                build_args.append('/p:PublishAot=true')
-                build_args.append('/p:PublishAotUsingRuntimePack=true')
             build_args.append("/p:EnableWindowsTargeting=true")
             self._publish(configuration=self.configuration, runtime_identifier=self.runtime_identifier, framework=self.framework, output=self.output, build_args=build_args)
         if self.operation == CROSSGEN:

--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -853,7 +853,7 @@ ex: C:\repos\performance;C:\repos\runtime
                         if 'Now monitoring resource allowance' in lineData['eventMessage'] or 'Stopped monitoring' in lineData['eventMessage']:
                             events.append(lineData)
                     except:
-                        break
+                        continue
 
                 
                 if i == 0: # Use the warmup iteration to get the current device time

--- a/src/scenarios/shared/runner.py
+++ b/src/scenarios/shared/runner.py
@@ -714,18 +714,20 @@ ex: C:\repos\performance;C:\repos\runtime
             apple_state = RunCommand(cmdline, verbose=True)
             apple_state.run()
 
-            # Get the name and version of the device from the output of apple_state above
-            # Example output expected (PERFIOS-01 is the device name, and 17.0.2 is the version):
+            # Get the name, UDID, and version of the device from the output of apple_state above
+            # Example output expected (PERFIOS-01 is the device name, 00008101-001A09223E08001E is the UDID, and 17.0.2 is the version):
             #  Connected Devices:
             #    PERFIOS-01 00008101-001A09223E08001E    17.0.2        iPhone iOS
-            deviceInfoMatch = re.search(r'Connected Devices:\s+(?P<deviceName>\S+)\s+\S+\s+(?P<deviceVersion>\S+)', apple_state.stdout)
+            deviceInfoMatch = re.search(r'Connected Devices:\s+(?P<deviceName>\S+)\s+(?P<deviceUDID>\S+)\s+(?P<deviceVersion>\S+)', apple_state.stdout)
             if deviceInfoMatch:
                 deviceName = deviceInfoMatch.group('deviceName')
+                deviceUDID = deviceInfoMatch.group('deviceUDID')
                 deviceVersion = deviceInfoMatch.group('deviceVersion')
                 getLogger().info(f"Device Name: {deviceName}")
+                getLogger().info(f"Device UDID: {deviceUDID}")
                 getLogger().info(f"Device Version: {deviceVersion}")
             else:
-                raise Exception("Device name or version not found in the output of apple_state command.")
+                raise Exception("Device name, UDID, or version not found in the output of apple_state command.")
             
             getLogger().info("Installing app on device.")
             installCmd = xharnesscommand() + [
@@ -753,7 +755,7 @@ ex: C:\repos\performance;C:\repos\runtime
                     'mlaunch',
                     '--',
                     '--launchdev', self.packagepath,
-                    '--devname', deviceName
+                    '--devname', deviceUDID
                 ]
                 runCmdCommand = RunCommand(runCmd, verbose=True)
 
@@ -813,7 +815,7 @@ ex: C:\repos\performance;C:\repos\runtime
                     'mlaunch',
                     '--',
                     f'--killdev={app_pid}',
-                    '--devname', deviceName
+                    '--devname', deviceUDID
                 ]
                 killCmdCommand = RunCommand(killCmd, verbose=True)
                 killCmdCommand.run()

--- a/src/scenarios/shared/startup.py
+++ b/src/scenarios/shared/startup.py
@@ -88,7 +88,10 @@ class StartupWrapper(object):
             copytree(TRACEDIR, os.path.join(helix_upload_dir, 'traces'))
             if traits.upload_to_perflab_container:
                 import upload
-                upload.upload(self.reportjson, upload_container, UPLOAD_QUEUE, UPLOAD_STORAGE_URI)
+                upload_code = upload.upload(self.reportjson, upload_container, UPLOAD_QUEUE, UPLOAD_STORAGE_URI)
+                getLogger().info("Startup Upload Code: " + str(upload_code))
+                if upload_code != 0:
+                    sys.exit(upload_code)
 
     def runtests(self, traits: TestTraits):
         '''

--- a/src/scenarios/shared/versionmanager.py
+++ b/src/scenarios/shared/versionmanager.py
@@ -3,6 +3,7 @@ Version File Manager
 '''
 import json
 import os
+import platform
 import subprocess
 from performance.logger import getLogger
 from datetime import datetime
@@ -35,6 +36,13 @@ def get_version_from_dll_powershell(dll_path: str):
 def get_version_from_dll_powershell_ios(dll_path: str):
     result = subprocess.run(['pwsh', '-Command', rf'Get-ChildItem {dll_path} | Select-Object -ExpandProperty VersionInfo | Select-Object -ExpandProperty ProductVersion'], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=False)
     return result.stdout.decode('utf-8').strip()
+
+def get_version_from_dll(dll_path: str):
+    '''Cross-platform DLL version extraction. Uses powershell on Windows, pwsh elsewhere.'''
+    if platform.system() == 'Windows':
+        return get_version_from_dll_powershell(dll_path)
+    else:
+        return get_version_from_dll_powershell_ios(dll_path)
 
 def get_sdk_versions(dll_folder_path: str, windows_powershell: bool = True) -> dict[str, str]:
     '''
@@ -70,7 +78,7 @@ def get_sdk_versions(dll_folder_path: str, windows_powershell: bool = True) -> d
 
         return version, commit
 
-    powershell_cmd = get_version_from_dll_powershell if windows_powershell else get_version_from_dll_powershell_ios
+    powershell_cmd = get_version_from_dll
 
     mobile_sdks = {
         "net_android": "Mono.Android.dll",

--- a/src/tests/harness/BenchmarkDotNet.Extensions.Tests/BenchmarkDotNet.Extensions.Tests.csproj
+++ b/src/tests/harness/BenchmarkDotNet.Extensions.Tests/BenchmarkDotNet.Extensions.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0</TargetFrameworks>
+    <TargetFrameworks>net11.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/tools/CertHelper/CertHelper.csproj
+++ b/src/tools/CertHelper/CertHelper.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
       <TargetFramework>$(PERFLAB_TARGET_FRAMEWORKS)</TargetFramework>
       <!-- Supported target frameworks -->
-      <TargetFramework Condition="'$(TargetFramework)' == ''">net9.0</TargetFramework>
+      <TargetFramework Condition="'$(TargetFramework)' == ''">net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/tools/CertHelper/Constants.cs
+++ b/src/tools/CertHelper/Constants.cs
@@ -11,4 +11,5 @@ public class Constants
     public static readonly string Cert2Name = "LabCert2";
     public static readonly Uri Cert1Id = new Uri("https://test.vault.azure.net/certificates/LabCert1/07a7d98bf4884e5c40e690e02b96b3b4");
     public static readonly Uri Cert2Id = new Uri("https://test.vault.azure.net/certificates/LabCert2/07a7d98bf4884e5c41e690e02b96b3b4");
+    public static readonly string BootstrapClientId = "d98f3bcf-cb73-4c6f-956e-6cd194b83a59";
 }

--- a/src/tools/CertHelper/KeyVaultCert.cs
+++ b/src/tools/CertHelper/KeyVaultCert.cs
@@ -58,8 +58,8 @@ public class KeyVaultCert
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Local certificate authentication failed: {ex.Message}");
-                Console.WriteLine("Attempting bootstrap authentication...");
+                Console.Error.WriteLine($"Local certificate authentication failed: {ex.Message}");
+                Console.Error.WriteLine("Attempting bootstrap authentication...");
             }
         }
 
@@ -78,14 +78,14 @@ public class KeyVaultCert
         var helixConfigRoot = Environment.GetEnvironmentVariable("HELIX_CONFIG_ROOT");
         if (string.IsNullOrEmpty(helixConfigRoot))
         {
-            Console.WriteLine("HELIX_CONFIG_ROOT environment variable is not set, cannot bootstrap");
+            Console.Error.WriteLine("HELIX_CONFIG_ROOT environment variable is not set, cannot bootstrap");
             return null;
         }
 
         var pemFile = Path.Combine(helixConfigRoot, "client.pem");
         if (!File.Exists(pemFile))
         {
-            Console.WriteLine($"client.pem not found in {helixConfigRoot}, cannot bootstrap");
+            Console.Error.WriteLine($"client.pem not found in {helixConfigRoot}, cannot bootstrap");
             return null;
         }
 
@@ -105,7 +105,7 @@ public class KeyVaultCert
         }
         catch (Exception ex)
         {
-            Console.WriteLine($"Bootstrap authentication failed: {ex.Message}");
+            Console.Error.WriteLine($"Bootstrap authentication failed: {ex.Message}");
         }
 
         return null;

--- a/src/tools/CertHelper/LocalCert.cs
+++ b/src/tools/CertHelper/LocalCert.cs
@@ -12,12 +12,14 @@ namespace CertHelper;
 public class LocalCert : ILocalCert
 {
     public X509Certificate2Collection Certificates { get; set; }
+    public bool RequiresBootstrap { get; private set; }
     internal IX509Store LocalMachineCerts { get; set; }
 
     public LocalCert(IX509Store? store = null)
     {
         LocalMachineCerts = store ?? new TestableX509Store();
         Certificates = new X509Certificate2Collection();
+        RequiresBootstrap = false;
         GetLocalCerts();
     }
 
@@ -33,7 +35,8 @@ public class LocalCert : ILocalCert
 
         if (Certificates.Count < 2 || Certificates.Where(c => c == null).Count() > 0)
         {
-            throw new Exception("One or more certificates not found");
+            // Mark that bootstrapping is needed instead of throwing immediately
+            RequiresBootstrap = true;
         }
     }
 }
@@ -41,4 +44,5 @@ public class LocalCert : ILocalCert
 public interface ILocalCert
 {
     X509Certificate2Collection Certificates { get; set; }
+    bool RequiresBootstrap { get; }
 }

--- a/src/tools/CertHelper/Program.cs
+++ b/src/tools/CertHelper/Program.cs
@@ -50,9 +50,9 @@ internal class Program
         }
         catch (Exception ex)
         {
-            Console.WriteLine("Failed to rotate certificates");
-            Console.WriteLine(ex.Message);
-            Console.WriteLine(ex.StackTrace);
+            Console.Error.WriteLine("Failed to rotate certificates");
+            Console.Error.WriteLine(ex.Message);
+            Console.Error.WriteLine(ex.StackTrace);
         }
 
         using (var store = new X509Store(StoreName.My, StoreLocation.CurrentUser, OpenFlags.ReadWrite))

--- a/src/tools/CertHelperTests/CertRotatorTests.csproj
+++ b/src/tools/CertHelperTests/CertRotatorTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/src/tools/Reporting/Reporting.Tests/ReporterTests.cs
+++ b/src/tools/Reporting/Reporting.Tests/ReporterTests.cs
@@ -31,6 +31,65 @@ Metric         |Average                  |Min                      |Max
 CounterName    |10000000000000000.000 ns |10000000000000000.000 ns |10000000000000000.000 ns 
 ";
 
+    private const string NoResultsTable =
+@"TestName
+No results in file.
+";
+
+    [Fact]
+    public void WriteReportTableWithNoCounters()
+    {
+        var reporter = new Reporter(new NonPerfLabEnvironmentProviderMock());
+        var test = new Test { Name = "TestName" };
+        reporter.AddTest(test);
+        var table = reporter.WriteResultTable();
+        Assert.Equal(NoResultsTable, table);
+    }
+
+    [Fact]
+    public void WriteReportTableWithEmptyResults()
+    {
+        var reporter = new Reporter(new NonPerfLabEnvironmentProviderMock());
+        var test = new Test
+        {
+            Name = "TestName",
+            Counters = [
+                new Counter
+                {
+                    DefaultCounter = true,
+                    MetricName = "ns",
+                    Name = "CounterName",
+                    Results = []
+                }
+            ]
+        };
+        reporter.AddTest(test);
+        var table = reporter.WriteResultTable();
+        Assert.Equal(NoResultsTable, table);
+    }
+
+    [Fact]
+    public void WriteReportTableWithNullResults()
+    {
+        var reporter = new Reporter(new NonPerfLabEnvironmentProviderMock());
+        var test = new Test
+        {
+            Name = "TestName",
+            Counters = [
+                new Counter
+                {
+                    DefaultCounter = true,
+                    MetricName = "ns",
+                    Name = "CounterName",
+                    Results = null
+                }
+            ]
+        };
+        reporter.AddTest(test);
+        var table = reporter.WriteResultTable();
+        Assert.Equal(NoResultsTable, table);
+    }
+
     [Fact]
     public void ReporterWithUnsetEnvironmentProducesNoJson()
     {

--- a/src/tools/Reporting/Reporting.Tests/Reporting.Tests.csproj
+++ b/src/tools/Reporting/Reporting.Tests/Reporting.Tests.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net10.0</TargetFrameworks>
+    <TargetFrameworks>net11.0</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\Reporting\Reporting.csproj" />
   </ItemGroup>

--- a/src/tools/Reporting/Reporting/Reporter.cs
+++ b/src/tools/Reporting/Reporting/Reporter.cs
@@ -72,16 +72,27 @@ public class Reporter
         var ret = new StringBuilder();
         foreach (var test in Tests)
         {
+            if (!test.Counters.Any() || test.Counters.All(c => c.Results == null || c.Results.Count == 0))
+            {
+                ret.AppendLine(test.Name);
+                ret.AppendLine("No results in file.");
+                continue;
+            }
+
+            var countersWithResults = test.Counters.Where(c => c.Results != null && c.Results.Count > 0);
             var counterWidth = Math.Max(test.Counters.Max(c => c.Name.Length) + 1, 15);
-            var resultWidth = Math.Max(test.Counters.Max(c => c.Results.Max().ToString("F3", _culture).Length + c.MetricName.Length) + 2, 15);
+            var resultWidth = Math.Max(countersWithResults.Max(c => c.Results.Max().ToString("F3", _culture).Length + c.MetricName.Length) + 2, 15);
             ret.AppendLine(test.Name);
             ret.AppendLine($"{LeftJustify("Metric", counterWidth)}|{LeftJustify("Average", resultWidth)}|{LeftJustify("Min", resultWidth)}|{LeftJustify("Max", resultWidth)}");
             ret.AppendLine($"{new string('-', counterWidth)}|{new string('-', resultWidth)}|{new string('-', resultWidth)}|{new string('-', resultWidth)}");
 
-            var defaultCounter = test.Counters.Single(c => c.DefaultCounter);
-            ret.AppendLine(PrintCounter(defaultCounter, counterWidth, resultWidth));
-            var topCounters = test.Counters.Where(c => c.TopCounter && !c.DefaultCounter);
-            var restCounters = test.Counters.Where(c => !c.TopCounter && !c.DefaultCounter);
+            var defaultCounter = test.Counters.SingleOrDefault(c => c.DefaultCounter);
+            if (defaultCounter != null && defaultCounter.Results != null && defaultCounter.Results.Count > 0)
+            {
+                ret.AppendLine(PrintCounter(defaultCounter, counterWidth, resultWidth));
+            }
+            var topCounters = test.Counters.Where(c => c.TopCounter && !c.DefaultCounter && c.Results != null && c.Results.Count > 0);
+            var restCounters = test.Counters.Where(c => !c.TopCounter && !c.DefaultCounter && c.Results != null && c.Results.Count > 0);
             foreach (var counter in topCounters.Concat(restCounters))
             {
                 ret.AppendLine(PrintCounter(counter, counterWidth, resultWidth));

--- a/src/tools/ResultsComparer/Data.cs
+++ b/src/tools/ResultsComparer/Data.cs
@@ -162,6 +162,10 @@ namespace ResultsComparer
                 return "net10.0";
             if (key.StartsWith("nativeaot10.0"))
                 return key;
+            if (key.StartsWith("net11.0"))
+                return "net11.0";
+            if (key.StartsWith("nativeaot11.0"))
+                return key;
 
             return null;
         }

--- a/src/tools/ResultsComparer/DataTransferContracts.cs
+++ b/src/tools/ResultsComparer/DataTransferContracts.cs
@@ -88,7 +88,7 @@ namespace DataTransferContracts // generated with http://json2csharp.com/#
         public int Gen1Collections { get; set; }
         public int Gen2Collections { get; set; }
         public long TotalOperations { get; set; }
-        public long BytesAllocatedPerOperation { get; set; }
+        public long? BytesAllocatedPerOperation { get; set; }
     }
 
     public class Measurement

--- a/src/tools/ResultsComparer/MultipleInputsComparer.cs
+++ b/src/tools/ResultsComparer/MultipleInputsComparer.cs
@@ -103,10 +103,10 @@ namespace ResultsComparer
 
         private static string GetAllocatedDiff(Benchmark diffResult, Benchmark baseResult)
         {
-            long baseline = baseResult.Memory.BytesAllocatedPerOperation;
+            long baseline = baseResult.Memory.BytesAllocatedPerOperation ?? 0;
             if (baseline == 0)
                 baseline = GetMetricValue(baseResult);
-            long diff = diffResult.Memory.BytesAllocatedPerOperation;
+            long diff = diffResult.Memory.BytesAllocatedPerOperation ?? 0;
             if (diff == 0)
                 diff = GetMetricValue(diffResult);
 

--- a/src/tools/ScenarioMeasurement/Startup/Startup.cs
+++ b/src/tools/ScenarioMeasurement/Startup/Startup.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
 using System.IO;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
@@ -339,7 +340,19 @@ public class Startup
             try
             {
                 var counters = parser.Parse(traceFilePath, processName, pids, commandLine);
-                CreateTestReport(scenarioName, counters, reportJsonPath, logger);
+                if (!counters.Any() || counters.All(c => c.Results == null || c.Results.Count == 0))
+                {
+                    logger.Log("ERROR: Parser returned no results. The ETL trace may not contain the expected events.");
+                    logger.Log($"{nameof(parser)} = {parser.GetType().FullName}");
+                    logger.Log($"{nameof(processName)} = {processName}");
+                    logger.Log($"{nameof(pids)} = {string.Join(", ", pids)}");
+                    logger.Log($"{nameof(commandLine)} = {commandLine}");
+                    failed = true;
+                }
+                if (!failed)
+                {
+                    CreateTestReport(scenarioName, counters, reportJsonPath, logger);
+                }
             }
             catch
             {


### PR DESCRIPTION
Adds two new benchmark classes to exercise the LeadingStrings vs FixedDistanceSets heuristic in the regex engine:

- **Perf_Regex_LeadingStrings_BinaryData**: 1MB binary corpus (PE-header-like seed duplicated), alternation of binary patterns. Validates no regression on non-text input.
- **Perf_Regex_LeadingStrings_NonAscii**: ~100KB Russian text (Anna Karenina opening), alternation of Russian words. Validates no regression on non-ASCII text where the frequency heuristic bails out.

Companion to dotnet/runtime change: https://github.com/danmoseley/runtime/pull/30
